### PR TITLE
Bump promesa to 2.x

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -6,14 +6,14 @@
 
                                      ;; Add-ons:
                                      org.clojure/core.async {:mvn/version "0.4.474"}
-                                     funcool/promesa {:mvn/version "1.10.0-SNAPSHOT"}}}
+                                     funcool/promesa {:mvn/version "2.0.0-SNAPSHOT"}}}
 
            :test-clj {:extra-paths ["test/clj" "test/cljc"]
                       :extra-deps  {org.clojure/clojure {:mvn/version "1.9.0"}
                                     ;; Add-ons:
                                     org.clojure/core.async {:mvn/version "0.4.474"}
                                     manifold {:mvn/version "0.1.8"}
-                                    funcool/promesa {:mvn/version "1.10.0-SNAPSHOT"}
+                                    funcool/promesa {:mvn/version "2.0.0-SNAPSHOT"}
                                     ;; Dev:
                                     org.clojure/tools.namespace {:mvn/version "0.2.11"}
                                     ;; Testing:

--- a/project.clj
+++ b/project.clj
@@ -12,7 +12,7 @@
                                   ;; Add-ons:
                                   [org.clojure/core.async "0.4.490"]
                                   [manifold "0.1.8"]
-                                  [funcool/promesa "1.10.0-SNAPSHOT"]
+                                  [funcool/promesa "2.0.0-SNAPSHOT"]
                                   ;; Dev:
                                   [org.clojure/tools.namespace "0.2.11"]
                                   ;; Testing:

--- a/src/sieppari/async/promesa.cljc
+++ b/src/sieppari/async/promesa.cljc
@@ -12,5 +12,5 @@
 
 #?(:cljs
    (extend-protocol sa/AsyncContext
-     p/Promise
+     js/Promise
      (continue [this f] (p/chain this f))))


### PR DESCRIPTION
This is potentially a breaking change. Promesa now extends the default
js/Promise - ditching Bluebird - and therefore we need to make sure that our
extend-protocol still works.