### PR TITLE
[WIP] Plain Context API (no request/response)

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,9 +34,16 @@ If you are familiar with interceptors you might want to jump to `Differences to 
 (defn handler [request]
   {:y (inc (:x request))})
 
+;; `sieppari/execute` takes the `:request` value as last argument
 (sieppari/execute
   [inc-x-interceptor handler]
   {:x 40})
+;=> {:y 42}
+
+;; `sieppari/execute-ctx` takes the full context as last argument
+(sieppari/execute-ctx
+  [inc-x-interceptor handler]
+  {:request {:x 40}})
 ;=> {:y 42}
 ```
 

--- a/src/sieppari/core.cljc
+++ b/src/sieppari/core.cljc
@@ -50,14 +50,14 @@
 #?(:clj
    (defn- await-result [ctx get-result]
      (if (a/async? ctx)
-       (recur (a/await ctx))
+       (recur (a/await ctx) get-result)
        (if-let [error (:error ctx)]
          (throw error)
          (get-result ctx)))))
 
 (defn- deliver-result [ctx get-result]
   (if (a/async? ctx)
-    (a/continue ctx deliver-result)
+    (a/continue ctx #(deliver-result % get-result))
     (let [error    (:error ctx)
           result   (or error (get-result ctx))
           callback (if error :on-error :on-complete)

--- a/src/sieppari/core.cljc
+++ b/src/sieppari/core.cljc
@@ -61,7 +61,7 @@
     (let [error    (:error ctx)
           result   (or error (:response ctx))
           callback (if error :on-error :on-complete)
-          f        (callback ctx identity)]
+          f        (get ctx callback identity)]
       (f result))))
 
 (defn- context

--- a/test/clj/sieppari/core_test.clj
+++ b/test/clj/sieppari/core_test.clj
@@ -20,7 +20,8 @@
     @(try-f {} (fn [_] (future (ex-info "oh no" {}))))
     =eventually-in=> {:error (ex-info? "oh no" {})}))
 
-(def await-result #'s/await-result)
+(defn await-result [ctx]
+  (#'s/await-result ctx :response))
 
 (def error (RuntimeException. "kosh"))
 


### PR DESCRIPTION
This tries to address some of the requests (#15 & #28) for a more context focused API (i.e. without the request/response concepts).

`execute-ctx` still returns only the `:response` value but that's probably something we can figure out. 

The main goal here is that we can move forward with a Context-based API while maintaining the previous request/response style for backwards compatibility.

cc @dspiteself @jjttjj @den1k 