### PR TITLE
Add Context API

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,8 @@ The core _Sieppari_ depends on Clojure and nothing else.
 
 If you are new to interceptors, check the
 [Pedestal Interceptors documentation](http://pedestal.io/reference/interceptors).
-If you are familiar with interceptors you might want to jump to `Differences to Pedestal` below.
+Sieppari's `sieppari.core/execute` follows a `:request` / `:response` pattern. For
+Pedestal-like behavior, use `sieppari.core/execute-context`.
 
 ## First example
 
@@ -165,11 +166,6 @@ in async case they all return `core.async` channels on enter and leave.
 * Clojure 1.9.0
 
 # Differences to Pedestal
-
-## Execution
-
-* `io.pedestal.interceptor.chain/execute` executes _Contexts_
-* `sieppari.core/execute` executes _Requests_ (which are internally wrapped inside a _Context_ for interceptors)
 
 ## Errors
 

--- a/src/sieppari/core.cljc
+++ b/src/sieppari/core.cljc
@@ -75,6 +75,9 @@
 ;;
 
 (defn execute-context
+  {:arglists
+   '([interceptors ctx]
+     [interceptors ctx on-complete on-error])}
   ([interceptors ctx on-complete on-error]
    (execute-context interceptors ctx on-complete on-error remove-context-keys))
   ([interceptors ctx on-complete on-error get-result]
@@ -101,6 +104,9 @@
             (await-result get-result))))))
 
 (defn execute
+  {:arglists
+   '([interceptors request]
+     [interceptors request on-complete on-error])}
   ([interceptors request on-complete on-error]
    (execute-context interceptors {:request request} on-complete on-error :response))
   #?(:clj

--- a/src/sieppari/core.cljc
+++ b/src/sieppari/core.cljc
@@ -5,7 +5,7 @@
             #?(:cljs [goog.iter :as iter]))
   #?(:clj (:import (java.util Iterator))))
 
-(defrecord Context [request response error queue stack on-complete on-error])
+(defrecord Context [error queue stack on-complete on-error])
 
 (defn- try-f [ctx f]
   (if f
@@ -44,51 +44,65 @@
                    (assoc :queue (pop queue))
                    (assoc :stack #?(:clj  (conj stack interceptor)
                                     :cljs (doto (or stack (array))
-                                                (.unshift interceptor))))
+                                            (.unshift interceptor))))
                    (try-f (:enter interceptor))))))))
 
 #?(:clj
-   (defn- await-result [ctx]
+   (defn- await-result [ctx get-result]
      (if (a/async? ctx)
-       (recur (a/await ctx))
+       (recur (a/await ctx) get-result)
        (if-let [error (:error ctx)]
          (throw error)
-         (:response ctx)))))
+         (get-result ctx)))))
 
-(defn- deliver-result [ctx]
+(defn- deliver-result [ctx get-result]
   (if (a/async? ctx)
-    (a/continue ctx deliver-result)
+    (a/continue ctx #(deliver-result % get-result))
     (let [error    (:error ctx)
-          result   (or error (:response ctx))
+          result   (or error (get-result ctx))
           callback (if error :on-error :on-complete)
           f        (callback ctx identity)]
       (f result))))
 
-(defn- context
-  ([request queue]
-   (new Context request nil nil queue nil nil nil))
-  ([request queue on-complete on-error]
-   (new Context request nil nil queue nil on-complete on-error)))
+(defn- context [m]
+  (map->Context m))
+
+(defn- remove-context-keys [ctx]
+  (dissoc ctx :error :queue :stack :on-complete :on-error))
 
 ;;
 ;; Public API:
 ;;
 
-(defn execute
-  ([interceptors request on-complete on-error]
+(defn execute-context
+  ([interceptors ctx on-complete on-error]
+   (execute-context interceptors ctx on-complete on-error remove-context-keys))
+  ([interceptors ctx on-complete on-error get-result]
    (if-let [queue (q/into-queue interceptors)]
-     (-> (context request queue on-complete on-error)
+     (-> (assoc ctx :queue queue :on-complete on-complete :on-error on-error)
+         (context)
          (enter)
          (leave)
-         (deliver-result))
+         (deliver-result get-result))
      ;; It is always necessary to call on-complete or the computation would not
      ;; keep going.
      (on-complete nil))
    nil)
   #?(:clj
-     ([interceptors request]
+     ([interceptors ctx]
+      (execute-context interceptors ctx remove-context-keys)))
+  #?(:clj
+     ([interceptors ctx get-result]
       (when-let [queue (q/into-queue interceptors)]
-        (-> (context request queue)
+        (-> (assoc ctx :queue queue)
+            (context)
             (enter)
             (leave)
-            (await-result))))))
+            (await-result get-result))))))
+
+(defn execute
+  ([interceptors request on-complete on-error]
+   (execute-context interceptors {:request request} on-complete on-error :response))
+  #?(:clj
+     ([interceptors request]
+      (execute-context interceptors {:request request} :response))))

--- a/test/clj/sieppari/core_async_test.clj
+++ b/test/clj/sieppari/core_async_test.clj
@@ -68,6 +68,24 @@
     (fact
       response => request)))
 
+(deftest execute-context-setup-async-test-test
+  (let [log (atom [])
+        response (-> [(make-async-logging-interceptor log :a)
+                      (make-async-logging-interceptor log :b)
+                      (make-async-logging-interceptor log :c)
+                      (make-async-logging-handler log)]
+                     (sc/execute-context {:request request}))]
+    (fact
+     @log => [[:enter :a]
+              [:enter :b]
+              [:enter :c]
+              [:handler]
+              [:leave :c]
+              [:leave :b]
+              [:leave :a]])
+    (fact
+     (:response response) => request)))
+
 (deftest async-b-sync-execute-test
   (let [log (atom [])
         response (-> [(make-logging-interceptor log :a)

--- a/test/clj/sieppari/core_execute_test.clj
+++ b/test/clj/sieppari/core_execute_test.clj
@@ -19,12 +19,12 @@
 (defn unexpected [name stage]
   (fn [ctx]
     (throw (ex-info "unexpected invocation"
-                    {:name name
+                    {:name  name
                      :stage stage
-                     :ctx ctx}))))
+                     :ctx   ctx}))))
 
 (defn make-test-interceptor [name]
-  {:name name
+  {:name  name
    :enter (unexpected name :enter)
    :leave (unexpected name :leave)
    :error (unexpected name :error)})
@@ -53,7 +53,14 @@
 ;; that `ctx` contains an exception caused by `always-throw`,
 ;; clears the exception and sets response to given response:
 
-(defn handle-error [response]
+(defn handle-error [overwrite-context]
+  (fn [ctx]
+    (assert (-> ctx :error ex-data (= {::error-marker true})))
+    (-> ctx
+        (dissoc :error)
+        (merge overwrite-context))))
+
+(defn handle-error-response [response]
   (fn [ctx]
     (assert (not (some? (:response ctx))))
     (assert (-> ctx :error ex-data (= {::error-marker true})))
@@ -65,88 +72,182 @@
 ;; Tests:
 ;;
 
+;;`execute-context` Tests
+
+(deftest execute-context-test
+  (fact "enable all enter and leave stages, add `inc` interceptor"
+        (-> test-chain
+            (assoc-in [a-index :enter] identity)
+            (assoc-in [b-index :enter] identity)
+            (assoc-in [c-index :enter] identity)
+            (assoc-in [h-index] {:enter (fn [ctx] (update ctx :data inc))})
+            (assoc-in [c-index :leave] identity)
+            (assoc-in [b-index :leave] identity)
+            (assoc-in [a-index :leave] identity)
+            (s/execute-context {:data 41}))
+        => {:data 42}))
+
+(deftest execute-context-enter-b-causes-exception-test
+  (fact ":b causes an exception"
+        (-> test-chain
+            (assoc-in [a-index :enter] identity)
+            (assoc-in [b-index :enter] always-throw)
+            (assoc-in [b-index :error] identity)
+            (assoc-in [a-index :error] identity)
+            (s/execute-context {:data 41}))
+        =throws=> error))
+
+(deftest execute-context-enter-c-causes-exception-a-handles-test
+  (fact ":c enter causes an exception, :b sees error, :a handles"
+        (-> test-chain
+            (assoc-in [a-index :enter] identity)
+            (assoc-in [b-index :enter] identity)
+            (assoc-in [c-index :enter] always-throw)
+            (assoc-in [c-index :error] identity)
+            (assoc-in [b-index :error] identity)
+            (assoc-in [a-index :error] (handle-error {:data :fixed-by-a}))
+            (s/execute-context {:data 41}))
+        => {:data :fixed-by-a}))
+
+(deftest execute-context-enter-c-causes-exception-b-handles-test
+  (fact ":c enter causes an exception, :b handles"
+        (-> test-chain
+            (assoc-in [a-index :enter] identity)
+            (assoc-in [b-index :enter] identity)
+            (assoc-in [c-index :enter] always-throw)
+            (assoc-in [c-index :error] identity)
+            (assoc-in [b-index :error] (handle-error {:data :fixed-by-b}))
+            (assoc-in [a-index :leave] identity)
+            (s/execute-context {:data 41}))
+        => {:data :fixed-by-b}))
+
+
+(deftest execute-context-enter-b-sets-response-test
+  (fact ":b sets the response, no invocation of :c nor :handler"
+        (-> test-chain
+            (assoc-in [a-index :enter] identity)
+            (assoc-in [b-index :enter] (fn [ctx] (sc/terminate
+                                                  (assoc ctx :data :response-by-b))))
+            (assoc-in [b-index :leave] identity)
+            (assoc-in [a-index :leave] identity)
+            (s/execute-context {:data 41}))
+        => {:data :response-by-b}))
+
+(deftest execute-context-empty-interceptors-test
+  (facts "interceptor chain can be empty"
+         (s/execute-context [] {}) => nil))
+
+(defn make-logging-interceptor [name]
+  {:name  name
+   :enter (fn [ctx]
+            (update ctx :request conj [:enter name]))
+   :leave (fn [ctx]
+            (update ctx :response conj [:leave name]))})
+
+(defn logging-handler [request]
+  (conj request [:handler]))
+
+(deftest execute-context-inject-interceptor-test
+  (fact ":b injects interceptor :x to chain, ensure the order is correct"
+        (-> [(make-logging-interceptor :a)
+             {:enter (fn [ctx] (sc/inject ctx (make-logging-interceptor :x)))}
+             (make-logging-interceptor :c)
+             logging-handler]
+            (s/execute-context {:request []})
+            :response)
+        => [[:enter :a]
+            [:enter :x]
+            [:enter :c]
+            [:handler]
+            [:leave :c]
+            [:leave :x]
+            [:leave :a]]))
+
+
+;;`execute` Tests
+
 (deftest happy-case-test
   (fact "enable all enter and leave stages, use `inc` as handler"
-    (-> test-chain
-        (assoc-in [a-index :enter] identity)
-        (assoc-in [b-index :enter] identity)
-        (assoc-in [c-index :enter] identity)
-        (assoc-in [h-index] inc)
-        (assoc-in [c-index :leave] identity)
-        (assoc-in [b-index :leave] identity)
-        (assoc-in [a-index :leave] identity)
-        (s/execute 41))
-    => 42))
+        (-> test-chain
+            (assoc-in [a-index :enter] identity)
+            (assoc-in [b-index :enter] identity)
+            (assoc-in [c-index :enter] identity)
+            (assoc-in [h-index] inc)
+            (assoc-in [c-index :leave] identity)
+            (assoc-in [b-index :leave] identity)
+            (assoc-in [a-index :leave] identity)
+            (s/execute 41))
+        => 42))
 
 (deftest enter-b-causes-exception-test
   (fact ":b causes an exception"
-    (-> test-chain
-        (assoc-in [a-index :enter] identity)
-        (assoc-in [b-index :enter] always-throw)
-        (assoc-in [b-index :error] identity)
-        (assoc-in [a-index :error] identity)
-        (s/execute 41))
-    =throws=> error))
+        (-> test-chain
+            (assoc-in [a-index :enter] identity)
+            (assoc-in [b-index :enter] always-throw)
+            (assoc-in [b-index :error] identity)
+            (assoc-in [a-index :error] identity)
+            (s/execute 41))
+        =throws=> error))
 
 (deftest enter-c-causes-exception-a-handles-test
   (fact ":c enter causes an exception, :b sees error, :a handles"
-    (-> test-chain
-        (assoc-in [a-index :enter] identity)
-        (assoc-in [b-index :enter] identity)
-        (assoc-in [c-index :enter] always-throw)
-        (assoc-in [c-index :error] identity)
-        (assoc-in [b-index :error] identity)
-        (assoc-in [a-index :error] (handle-error :fixed-by-a))
-        (s/execute 41))
-    => :fixed-by-a))
+        (-> test-chain
+            (assoc-in [a-index :enter] identity)
+            (assoc-in [b-index :enter] identity)
+            (assoc-in [c-index :enter] always-throw)
+            (assoc-in [c-index :error] identity)
+            (assoc-in [b-index :error] identity)
+            (assoc-in [a-index :error] (handle-error-response :fixed-by-a))
+            (s/execute 41))
+        => :fixed-by-a))
 
 (deftest enter-c-causes-exception-b-handles-test
   (fact ":c enter causes an exception, :b handles"
-    (-> test-chain
-        (assoc-in [a-index :enter] identity)
-        (assoc-in [b-index :enter] identity)
-        (assoc-in [c-index :enter] always-throw)
-        (assoc-in [c-index :error] identity)
-        (assoc-in [b-index :error] (handle-error :fixed-by-b))
-        (assoc-in [a-index :leave] identity)
-        (s/execute 41))
-    => :fixed-by-b))
+        (-> test-chain
+            (assoc-in [a-index :enter] identity)
+            (assoc-in [b-index :enter] identity)
+            (assoc-in [c-index :enter] always-throw)
+            (assoc-in [c-index :error] identity)
+            (assoc-in [b-index :error] (handle-error-response :fixed-by-b))
+            (assoc-in [a-index :leave] identity)
+            (s/execute 41))
+        => :fixed-by-b))
 
 (deftest handler-causes-exception-b-handles-test
   (fact
-    (-> test-chain
-        (assoc-in [a-index :enter] identity)
-        (assoc-in [b-index :enter] identity)
-        (assoc-in [c-index :enter] identity)
-        (assoc-in [h-index] always-throw)
-        (assoc-in [c-index :error] identity)
-        (assoc-in [b-index :error] (handle-error :fixed-by-b))
-        (assoc-in [a-index :leave] identity)
-        (s/execute 41))
-    => :fixed-by-b))
+   (-> test-chain
+       (assoc-in [a-index :enter] identity)
+       (assoc-in [b-index :enter] identity)
+       (assoc-in [c-index :enter] identity)
+       (assoc-in [h-index] always-throw)
+       (assoc-in [c-index :error] identity)
+       (assoc-in [b-index :error] (handle-error-response :fixed-by-b))
+       (assoc-in [a-index :leave] identity)
+       (s/execute 41))
+   => :fixed-by-b))
 
 (deftest enter-b-sets-response-test
   (fact ":b sets the response, no invocation of :c nor :handler"
-    (-> test-chain
-        (assoc-in [a-index :enter] identity)
-        (assoc-in [b-index :enter] (fn [ctx] (sc/terminate ctx :response-by-b)))
-        (assoc-in [b-index :leave] identity)
-        (assoc-in [a-index :leave] identity)
-        (s/execute 41))
-    => :response-by-b))
+        (-> test-chain
+            (assoc-in [a-index :enter] identity)
+            (assoc-in [b-index :enter] (fn [ctx] (sc/terminate ctx :response-by-b)))
+            (assoc-in [b-index :leave] identity)
+            (assoc-in [a-index :leave] identity)
+            (s/execute 41))
+        => :response-by-b))
 
 (deftest nil-response-test
   (fact "nil response is allowed"
-    (s/execute [(constantly nil)] {})
-    => nil))
+        (s/execute [(constantly nil)] {})
+        => nil))
 
 (deftest empty-interceptors-test
   (facts "interceptor chain can be empty"
-    (s/execute [] {}) => nil
-    (s/execute nil {}) => nil))
+         (s/execute [] {}) => nil
+         (s/execute nil {}) => nil))
 
 (defn make-logging-interceptor [name]
-  {:name name
+  {:name  name
    :enter (fn [ctx]
             (update ctx :request conj [:enter name]))
    :leave (fn [ctx]
@@ -157,35 +258,34 @@
 
 (deftest inject-interceptor-test
   (fact ":b injects interceptor :x to chain, ensure the order is correct"
-    (-> [(make-logging-interceptor :a)
-         {:enter (fn [ctx] (sc/inject ctx (make-logging-interceptor :x)))}
-         (make-logging-interceptor :c)
-         logging-handler]
-        (s/execute []))
-    => [[:enter :a]
-        [:enter :x]
-        [:enter :c]
-        [:handler]
-        [:leave :c]
-        [:leave :x]
-        [:leave :a]]))
+        (-> [(make-logging-interceptor :a)
+             {:enter (fn [ctx] (sc/inject ctx (make-logging-interceptor :x)))}
+             (make-logging-interceptor :c)
+             logging-handler]
+            (s/execute []))
+        => [[:enter :a]
+            [:enter :x]
+            [:enter :c]
+            [:handler]
+            [:leave :c]
+            [:leave :x]
+            [:leave :a]]))
 
 ; TODO: figure out how enqueue should work? Should enqueue add interceptors just
 ; before the handler?
-#_
-    (deftest enqueue-interceptor-test
-      (fact ":b enqueues interceptor :x to chain, ensure the order is correct"
-        (-> [(make-logging-interceptor :a)
-             {:enter (fn [ctx] (sc/enqueue ctx (make-logging-interceptor :x)))}
-             (make-logging-interceptor :c)
-             logging-handler]
-            (sc/into-interceptors)
-            (s/execute []))
-        => [[:enter :a]
-            [:enter :c]
-            [:enter :x]
-            [:handler]
-            [:leave :x]
-            [:leave :c]
-            [:leave :a]]))
+#_(deftest enqueue-interceptor-test
+    (fact ":b enqueues interceptor :x to chain, ensure the order is correct"
+          (-> [(make-logging-interceptor :a)
+               {:enter (fn [ctx] (sc/enqueue ctx (make-logging-interceptor :x)))}
+               (make-logging-interceptor :c)
+               logging-handler]
+              (sc/into-interceptors)
+              (s/execute []))
+          => [[:enter :a]
+              [:enter :c]
+              [:enter :x]
+              [:handler]
+              [:leave :x]
+              [:leave :c]
+              [:leave :a]]))
 

--- a/test/clj/sieppari/core_test.clj
+++ b/test/clj/sieppari/core_test.clj
@@ -26,23 +26,23 @@
 
 (deftest wait-result-core-async-test
   (facts "response"
-    (await-result {:response :ctx}) => :ctx
-    (await-result (a/go {:response :ctx})) => :ctx
-    (await-result (a/go (a/go {:response :ctx}))) => :ctx)
+    (await-result {:response :ctx} :response) => :ctx
+    (await-result (a/go {:response :ctx}) :response) => :ctx
+    (await-result (a/go (a/go {:response :ctx})) :response) => :ctx)
   (facts "error"
-    (await-result {:error error}) =throws=> error
-    (await-result (a/go {:error error})) =throws=> error
-    (await-result (a/go (a/go {:error error}))) =throws=> error))
+    (await-result {:error error} :response) =throws=> error
+    (await-result (a/go {:error error}) :response) =throws=> error
+    (await-result (a/go (a/go {:error error})) :response) =throws=> error))
 
 (deftest wait-result-deref-test
   (facts "response"
-    (await-result {:response :ctx}) => :ctx
-    (await-result (future {:response :ctx})) => :ctx
-    (await-result (future (future {:response :ctx}))) => :ctx)
+    (await-result {:response :ctx} :response) => :ctx
+    (await-result (future {:response :ctx}) :response) => :ctx
+    (await-result (future (future {:response :ctx})) :response) => :ctx)
   (facts "exception"
-    (await-result {:error error}) =throws=> error
-    (await-result (future {:error error})) =throws=> error
-    (await-result (future (future {:error error}))) =throws=> error))
+    (await-result {:error error} :response) =throws=> error
+    (await-result (future {:error error}) :response) =throws=> error
+    (await-result (future (future {:error error})) :response) =throws=> error))
 
 (def deliver-result #'s/deliver-result)
 
@@ -52,34 +52,39 @@
   (let [p (promise)]
     (deliver-result {:response :r
                      :on-complete p
-                     :on-error fail!})
+                     :on-error fail!}
+                    :response)
     (fact
       @p =eventually=> :r))
 
   (let [p (promise)]
     (deliver-result {:error (ex-info "oh no" {})
                      :on-complete fail!
-                     :on-error p})
+                     :on-error p}
+                    :response)
     (fact
       @p =eventually=> (ex-info? "oh no" {})))
 
   (let [p (promise)]
     (deliver-result (a/go {:response :r
                            :on-complete p
-                           :on-error fail!}))
+                           :on-error fail!})
+                    :response)
     (fact
       @p =eventually=> :r))
 
   (let [p (promise)]
     (deliver-result (a/go {:error (ex-info "oh no" {})
                            :on-complete fail!
-                           :on-error p}))
+                           :on-error p})
+                    :response)
     (fact
       @p =eventually=> (ex-info? "oh no" {})))
 
   (let [p (promise)]
     (deliver-result (future (a/go {:response :r
                                    :on-complete p
-                                   :on-error fail!})))
+                                   :on-error fail!}))
+                    :response)
     (fact
       @p =eventually=> :r)))


### PR DESCRIPTION
Inspired by @martinklepsch's #30 


- adds a context API under `sieppari.core/execute-context`.
- updated `sieppari.core/execute` to use execute context.
- updated tests
- added tests for execute-context
 - updated readme

Since this is performance critical I reran the performance benchmarks, once before and once after my changes which shows that performance is overall the same. See updated benchmarks below.