### PR TITLE
Make Sieppari fast again

### DIFF
--- a/src/sieppari/async.cljc
+++ b/src/sieppari/async.cljc
@@ -6,13 +6,10 @@
                    java.util.function.Function)))
 
 (defprotocol AsyncContext
+  (async? [t])
   (continue [t f])
   (catch [c f])
   #?(:clj (await [t])))
-
-(defn async?
-  [x]
-  (satisfies? AsyncContext x))
 
 #?(:clj
    (deftype FunctionWrapper [f]
@@ -22,7 +19,21 @@
 
 #?(:clj
    (extend-protocol AsyncContext
+     Object
+     (async? [_] false)
+     (continue [t f] (f t))
+     (await [t] t)))
+
+#?(:cljs
+   (extend-protocol AsyncContext
+     js/Object
+     (async? [_] false)
+     (continue [t f] (f t))))
+
+#?(:clj
+   (extend-protocol AsyncContext
      clojure.lang.IDeref
+     (async? [_] true)
      (continue [c f] (future (f @c)))
      (catch [c f] (future (let [c @c]
                             (if (exception? c) (f c) c))))
@@ -31,6 +42,7 @@
 #?(:clj
    (extend-protocol AsyncContext
      CompletionStage
+     (async? [_] true)
      (continue [this f]
        (.thenApply ^CompletionStage this
                    ^Function (->FunctionWrapper f)))
@@ -49,5 +61,6 @@
 #?(:cljs
    (extend-protocol AsyncContext
      js/Promise
+     (async? [_] true)
      (continue [t f] (.then t f))
      (catch [t f] (.catch t f))))

--- a/src/sieppari/async/core_async.cljc
+++ b/src/sieppari/async/core_async.cljc
@@ -8,6 +8,7 @@
 (extend-protocol sa/AsyncContext
   #?(:clj clojure.core.async.impl.protocols.Channel
      :cljs cljs.core.async.impl.channels/ManyToManyChannel)
+  (async? [_] true)
   (continue [c f] (go (f (cca/<! c))))
   (catch [c f] (go (let [c (cca/<! c)]
                      (if (exception? c) (f c) c))))

--- a/src/sieppari/async/manifold.clj
+++ b/src/sieppari/async/manifold.clj
@@ -4,11 +4,13 @@
 
 (extend-protocol sa/AsyncContext
   manifold.deferred.Deferred
+  (async? [_] true)
   (continue [d f] (d/chain'- nil d f))
   (catch [d f] (d/catch' d f))
   (await [d] (deref d))
 
   manifold.deferred.ErrorDeferred
+  (async? [_] true)
   (continue [d f] (d/chain'- nil d f))
   (catch [d f] (d/catch' d f))
   (await [d] (deref d)))

--- a/src/sieppari/core.cljc
+++ b/src/sieppari/core.cljc
@@ -21,7 +21,7 @@
 (defn- leave [ctx]
   (if (a/async? ctx)
     (a/continue ctx leave)
-    (let [it (:stack ctx)]
+    (let [^Iterator it (:stack ctx)]
       (if (.hasNext it)
         (let [stage (if (:error ctx) :error :leave)
               f     (-> it .next stage)]


### PR DESCRIPTION
Things to note:
- clj tests fail, but it's not my bad they fail in develop brach as well (I can look at it if it's needed);
- cljs tests pass, but there is a warning: Extending an existing JavaScript type - use a different symbol name instead of js/Object e.g object at line 28 sieppari/src/sieppari/async.cljc. It's just a js/object because some tests use numbers or persistent hash-maps as a context (not the Context record). I think that's it should be more specific what user can pass to executer as a context;
- Performance is great now.

Fixes #33