### PR TITLE
Cleanup running tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,4 +14,4 @@ jobs:
     - name: Install Clojure dependencies
       run: lein deps
     - name: Run tests
-      run: lein kaocha-cljs
+      run: lein kaocha

--- a/HACKING.md
+++ b/HACKING.md
@@ -3,8 +3,7 @@
 ## CLI
 
 ```shell script
-lein kaocha-clj unit # JVM
-lein kaocha-cljs unit-cljs # cljs on node
+lein kaocha # run clj and cljs tests
 ```
 
 `kaocha-cljs` [requires](https://github.com/lambdaisland/kaocha-cljs) `ws` and `isomorphic-ws` from npm.

--- a/HACKING.md
+++ b/HACKING.md
@@ -6,7 +6,7 @@
 lein kaocha # run clj and cljs tests
 ```
 
-`kaocha-cljs` [requires](https://github.com/lambdaisland/kaocha-cljs) `ws` and `isomorphic-ws` from npm.
+`kaocha-cljs` [requires](https://github.com/lambdaisland/kaocha-cljs#quickstart) `ws` from npm.
 A `package(-lock).json` is provided so you can just `npm install` those.
  
 ## REPL

--- a/README.md
+++ b/README.md
@@ -186,23 +186,6 @@ in async case they all return `core.async` channels on enter and leave.
 * _Pedestal_ transfers thread local bindings from call-site into async interceptors.
 * _Sieppari_ does not support this.
 
-# REPL
-
-In order to start a node figwheel REPL for local development use:
-
-```shell
-clojure -A:fig:test-cljs:nrepl
-```
-
-Then in the REPL:
-
-```
-user=> (require 'figwheel.main.api)
-nil
-user=> (figwheel.main.api/start "dev")
-...
-```
-
 # Thanks
 
 * Original idea from [Pedestal Interceptors](https://github.com/pedestal/pedestal/tree/master/interceptor).

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,19 +1,12 @@
 {
   "name": "sieppari",
-  "version": "0.0.0-alpha7",
-  "lockfileVersion": 1,
   "requires": true,
+  "lockfileVersion": 1,
   "dependencies": {
     "async-limiter": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.1.tgz",
       "integrity": "sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ==",
-      "dev": true
-    },
-    "isomorphic-ws": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/isomorphic-ws/-/isomorphic-ws-4.0.1.tgz",
-      "integrity": "sha512-BhBvN2MBpWTaSHdWRb/bwdZJ1WaehQ2L1KngkCkfLUGF0mAWAT1sQUQacEmQ0jXkFw/czDXPNQSL5u2/Krsz1w==",
       "dev": true
     },
     "ws": {

--- a/package.json
+++ b/package.json
@@ -1,9 +1,7 @@
 {
   "name": "sieppari",
-  "version": "0.0.0-alpha7",
   "description": "Small, fast, and complete interceptor library.",
   "devDependencies": {
-    "isomorphic-ws": "^4.0.1",
     "ws": "^7.1.2"
   },
   "repository": {

--- a/project.clj
+++ b/project.clj
@@ -23,14 +23,14 @@
                                        [criterium "0.4.5"]
                                        [io.pedestal/pedestal.interceptor "0.5.7"]
                                        [org.slf4j/slf4j-nop "1.7.30"]]}
-             :test-common [:dev-deps {:source-paths ["test/cljc"]}]
-             :test-clj {:source-paths ["test/clj"]}
-             :test-cljs {:source-paths ["test/cljs"]}
-             :dev [:dev-deps {:source-paths ["dev" "test/cljc" "test/clj" "test/cljs"]}]
+
+             ;; needed because of https://github.com/lambdaisland/kaocha-cljs#known-issues
+             :test-cljs {:source-paths ["test/cljc" "test/cljs"]}
+
+             :dev [:dev-deps {:source-paths ["dev"]}]
              :examples {:source-paths ["examples"]}
              :perf {:jvm-opts ^:replace ["-server" "-Xms4096m" "-Xmx4096m" "-Dclojure.compiler.direct-linking=true"]}}
 
-  :aliases {"kaocha-clj" ["with-profile" "+test-common,+test-clj" "run" "-m" "kaocha.runner"]
-            "kaocha-cljs" ["with-profile" "+test-common,+test-cljs" "run" "-m" "kaocha.runner"]
+  :aliases {"kaocha" ["with-profile" "+dev-deps,+test-cljs" "run" "-m" "kaocha.runner"]
             "perf" ["with-profile" "default,dev,examples,perf"]
             "perf-test" ["perf" "run" "-m" "example.perf-testing"]})

--- a/tests.edn
+++ b/tests.edn
@@ -1,6 +1,6 @@
 #kaocha/v1
-    {:tests [{:id :unit
-              :test-paths ["test/cljc" "test/clj"]}
-             {:id   :unit-cljs
-              :type :kaocha.type/cljs
-              :test-paths ["test/cljc" "test/cljs"]}]}
+{:tests [{:id         :unit
+          :test-paths ["test/cljc" "test/clj"]}
+         {:id         :unit-cljs
+          :type       :kaocha.type/cljs
+          :test-paths ["test/cljc" "test/cljs"]}]}


### PR DESCRIPTION
You can go through commits, they are all concise and cohesive.

**Changes**
- Simplified running tests.
- Got rid of `isomorphic-ws`, it's [not needed](https://github.com/lambdaisland/kaocha-cljs/blob/master/CHANGELOG.md#changed-3) anymore.
- Got rid of REPL section in readme, it's useless without `deps.edn`.