### PR TITLE
Context perf

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ Blocking on async computation:
 Any step can return a `java.util.concurrent.CompletionStage` or `js/promise`, Sieppari works oob with libraries like [Promesa](http://funcool.github.io/promesa/latest):
 
 ```clj
+;; [funcool/promesa "5.1.0"]`
 (require '[promesa.core :as p])
 
 (def chain
@@ -159,23 +160,6 @@ Requires dependency to `[manifold "0.1.8"]` or higher.
   [inc-x-interceptor (minus-x-interceptor 10) handler]
   {:x 40})
 ;=> {:y 31}
-```
-
-## promesa
-
-Requires dependency to `[funcool/promesa "2.0.0-SNAPSHOT"]` or higher.
-
-```clj
-(require '[promesa.core :as p])
-
-(defn divide-x-interceptor [n]
-  {:enter (fn [ctx]
-            (p/promise (update-in ctx [:request :x] / n)))})
-
-(s/execute
-  [inc-x-interceptor (divide-x-interceptor 10) handler]
-  {:x 40})
-;=> {:y 41/10}
 ```
 
 # Performance

--- a/README.md
+++ b/README.md
@@ -24,18 +24,17 @@ Pedestal-like behavior, use `sieppari.core/execute-context`.
 
 ```clj
 (ns example.simple
-  (:require [sieppari.core :as sieppari]))
+  (:require [sieppari.core :as s]))
 
 ;; interceptor, in enter update value in `[:request :x]` with `inc`
 (def inc-x-interceptor
-  {:enter (fn [ctx]
-            (update-in ctx [:request :x] inc))})
+  {:enter (fn [ctx] (update-in ctx [:request :x] inc))})
 
 ;; handler, take `:x` from request, apply `inc`, and return an map with `:y`
 (defn handler [request]
   {:y (inc (:x request))})
 
-(sieppari/execute
+(s/execute
   [inc-x-interceptor handler]
   {:x 40})
 ;=> {:y 42}
@@ -45,9 +44,9 @@ Pedestal-like behavior, use `sieppari.core/execute-context`.
 
 Any step in the execution pipeline (`:enter`, `:leave`, `:error`) can return either a context map (synchronous execution) or an instance of [`AsyncContext`](https://github.com/metosin/sieppari/blob/develop/src/sieppari/async.cljc) - indicating asynchronous execution.
 
-By default, clojure deferrables satisfy the `AsyncContext` protocol.
+By default, clojure deferrables, `java.util.concurrent.CompletionStage` and `js/promise` satisfy the `AsyncContext` protocol.
 
-Using `sieppari.core/execute` with async steps will block:
+Using `s/execute` with async steps will block:
 
 ```clj
 ;; async interceptor, in enter double value of `[:response :y]`:
@@ -58,19 +57,31 @@ Using `sieppari.core/execute` with async steps will block:
               (update-in ctx [:response :y] * 2)))})
 
 
-(sieppari/execute
+(s/execute
   [inc-x-interceptor multiply-y-interceptor handler]
   {:x 40})
 ; ... 1 second later:
 ;=> {:y 84}
 ```
 
-There is also a non-blocking version of `execute`:
+Using non-blocking version of `s/execute`:
+
+```clj
+(s/execute
+  [inc-x-interceptor multiply-y-interceptor handler]
+  {:x 40}
+  (partial println "SUCCESS:")
+  (partial println "FAILURE:"))
+; => nil
+; prints "SUCCESS: {:y 84}" 1sec later
+```
+
+Blocking on async computation:
 
 ```clj
 (let [respond (promise)
       raise (promise)]
-  (sieppari/execute
+  (s/execute
     [inc-x-interceptor multiply-y-interceptor handler]
     {:x 40}
     respond
@@ -81,6 +92,31 @@ There is also a non-blocking version of `execute`:
 ;=> {:y 84}
 ```
 
+Any step can return a `java.util.concurrent.CompletionStage` or `js/promise`, Sieppari works oob with libraries like [Promesa](http://funcool.github.io/promesa/latest):
+
+```clj
+(require '[promesa.core :as p])
+
+(def chain
+  [{:enter #(update-in % [:request :x] inc)}               ;; 1
+   {:leave #(p/promise (update-in % [:response :x] / 10))} ;; 4
+   {:enter #(p/delay 1000 %)}                              ;; 2
+   identity])                                              ;; 3
+
+;; blocking
+(s/execute chain {:x 40})
+; => {:x 41/10} after after 1sec
+
+;; non-blocking
+(s/execute
+  chain
+  {:x 40}
+  (partial println "SUCCESS:")
+  (partial println "SUCCESS:"))
+; => nil
+;; prints "SUCCESS: {:x 41/10}" after 1sec
+```
+
 ## External Async Libraries
 
 To add a support for one of the supported external async libraries, just add a dependency to them and `require` the
@@ -88,7 +124,6 @@ respective Sieppari namespace. Currently supported async libraries are:
 
 * [core.async](https://github.com/clojure/core.async) - `sieppari.async.core-async`, clj & cljs
 * [Manifold](https://github.com/ztellman/manifold) - `sieppari.async.manifold` clj
-* [Promesa](http://funcool.github.io/promesa/latest) - `sieppari.async.promesa` clj & cljs
 
 To extend Sieppari async support to other libraries, just extend the `AsyncContext` protocol.
 
@@ -103,7 +138,7 @@ Requires dependency to `[org.clojure/core.async "0.4.474"]` or higher.
   {:enter (fn [ctx]
             (a/go (update-in ctx [:request :x] * n)))})
 
-(sieppari/execute
+(s/execute
   [inc-x-interceptor (multiply-x-interceptor 10) handler]
   {:x 40})
 ;=> {:y 411}
@@ -120,7 +155,7 @@ Requires dependency to `[manifold "0.1.8"]` or higher.
   {:enter (fn [ctx]
             (d/success-deferred (update-in ctx [:request :x] - n)))})
 
-(sieppari/execute
+(s/execute
   [inc-x-interceptor (minus-x-interceptor 10) handler]
   {:x 40})
 ;=> {:y 31}
@@ -137,7 +172,7 @@ Requires dependency to `[funcool/promesa "2.0.0-SNAPSHOT"]` or higher.
   {:enter (fn [ctx]
             (p/promise (update-in ctx [:request :x] / n)))})
 
-(sieppari/execute
+(s/execute
   [inc-x-interceptor (divide-x-interceptor 10) handler]
   {:x 40})
 ;=> {:y 41/10}
@@ -162,8 +197,9 @@ All numbers are execution time lower quantile.
 
 | Executor          | sync   | promesa | core.async | manifold |
 | ----------------- | -------|---------|------------|----------|
-| Pedestal          | 8.2µs  |         | 92µs       |          |
+| Pedestal          | 8.2µs  |  -      | 92µs       | -        |
 | Sieppari          | 1.2µs  |  4.0µs  | 70µs       | 110µs    |
+| Middleware (comp) | 0.1µs  |  -      | -          | -        |
 
 * MacBook Pro (Retina, 15-inch, Mid 2015), 2.5 GHz Intel Core i7, 16 MB RAM
 * Java(TM) SE Runtime Environment (build 1.8.0_151-b12)
@@ -172,8 +208,8 @@ All numbers are execution time lower quantile.
 **NOTE**: running async flows without interceptors is still much faster,
 e.g. synchronous `manifold` chain is much faster than via interceptors.
 
-Plan is to add an Java-backed and optimized chain compiler into Sieppari, 
-making static synchronous chains on par with `clojure.core/comp`.
+**NOTE**: Plan is to add an Java-backed and optimized chain compiler into Sieppari, 
+making static synchronous chains on par with middleware chain / `comp`.
 
 # Differences to Pedestal
 

--- a/README.md
+++ b/README.md
@@ -193,7 +193,8 @@ Executing a chain of 10 interceptors, which have `:enter` of `clojure.core/ident
 * **core.async**: all step return the ctx in a `core.async` channel
 * **manifold**: all step return the ctx in a `manifold.deferred.Deferred`
 
-All numbers are execution time lower quantile.
+All numbers are execution time lower quantile (not testing the goodness of the async libraries
+, just the execution overhead sippari interceptors adds)
 
 | Executor          | sync   | promesa | core.async | manifold |
 | ----------------- | -------|---------|------------|----------|
@@ -208,8 +209,8 @@ All numbers are execution time lower quantile.
 **NOTE**: running async flows without interceptors is still much faster,
 e.g. synchronous `manifold` chain is much faster than via interceptors.
 
-**NOTE**: Plan is to add an Java-backed and optimized chain compiler into Sieppari, 
-making static synchronous chains on par with middleware chain / `comp`.
+**NOTE**: Goal is to have a Java-backed and optimized chain compiler into Sieppari,
+initial tests show it will be near the perf of middleware chain / `comp`.
 
 # Differences to Pedestal
 

--- a/README.md
+++ b/README.md
@@ -149,21 +149,31 @@ _Sieppari_ aims for minimal functionality and can therefore be
 quite fast. Complete example to test performance is
 [included](https://github.com/metosin/sieppari/blob/develop/examples/example/perf_testing.clj).
 
-The example creates a chain of 100 interceptors that have
-`clojure.core/identity` as `:enter` and `:leave` functions and then
-executes the chain. The async tests also have 100 interceptors, but
-in async case they all return `core.async` channels on enter and leave.
+## Silly numbers
 
-| Executor          | Execution time lower quantile |
-| ----------------- | ----------------------------- |
-| Pedestal sync     |  64 µs                        |
-| Sieppari sync     |   9 µs                        |
-| Pedestal async    | 410 µs                        |
-| Sieppari async    | 396 µs                        |
+Executing a chain of 10 interceptors, which have `:enter` of `clojure.core/identity`.
+
+* **sync**: all steps return the ctx
+* **promesa**: all steps return the ctx in an `promesa.core/promise`
+* **core.async**: all step return the ctx in a `core.async` channel
+* **manifold**: all step return the ctx in a `manifold.deferred.Deferred`
+
+All numbers are execution time lower quantile.
+
+| Executor          | sync   | promesa | core.async | manifold |
+| ----------------- | -------|---------|------------|----------|
+| Pedestal          | 8.2µs  |         | 92µs       |          |
+| Sieppari          | 1.2µs  |  4.0µs  | 70µs       | 110µs    |
 
 * MacBook Pro (Retina, 15-inch, Mid 2015), 2.5 GHz Intel Core i7, 16 MB RAM
 * Java(TM) SE Runtime Environment (build 1.8.0_151-b12)
 * Clojure 1.9.0
+
+**NOTE**: running async flows without interceptors is still much faster,
+e.g. synchronous `manifold` chain is much faster than via interceptors.
+
+Plan is to add an Java-backed and optimized chain compiler into Sieppari, 
+making static synchronous chains on par with `clojure.core/comp`.
 
 # Differences to Pedestal
 

--- a/examples/example/perf_testing.clj
+++ b/examples/example/perf_testing.clj
@@ -99,7 +99,7 @@
   (sq/into-queue (concat (repeat n i) [identity])))
 
 (defn create-s-mixed-chain [n i]
-  (sq/into-queue (concat (repeat (dec n) identity) [i identity])))
+  (sq/into-queue (concat (repeat (dec n) sync-interceptor) [i identity])))
 
 (defn run-simple-perf-test [n]
   (let [sync-interceptors (concat (repeat n sync-interceptor) [identity])
@@ -120,6 +120,7 @@
     (suite (str "queue of " n))
 
     ;; 8.2µs
+    ;; 8.2µs (context-api)
     (bench!
       "pedestal: sync"
       (->> p-sync-chain
@@ -128,6 +129,7 @@
            :response))
 
     ;; 99µs
+    ;; 92µs (context-api)
     (bench!
       "pedestal: core.async"
       (let [p (promise)]
@@ -138,12 +140,14 @@
 
     ;; 1.3µs
     ;; 2.1µs
+    ;; 1.2µs (context-api)
     (bench!
       "sieppari: sync (sync)"
       (s/execute s-sync-chain {}))
 
     ;; 1.3µs
     ;; 2,5µs
+    ;; 1.2µs (context-api)
     (bench!
       "sieppari: sync (async)"
       (let [p (promise)]
@@ -152,12 +156,14 @@
 
     ;; 61µs
     ;; 69µs
+    ;; 66µs (context-api)
     (bench!
       "sieppari: core.async (sync)"
       (s/execute s-async-chain {}))
 
     ;; 60µs
     ;; 65µs
+    ;; 70µs (context-api)
     (bench!
       "sieppari: core.async (async)"
       (let [p (promise)]
@@ -165,13 +171,16 @@
         @p))
 
     ;; 140µs
+    ;; 140µs (context-api)
     (bench!
       "sieppari: future (async)"
       (let [p (promise)]
         (s/execute s-future-chain {} p identity)
         @p))
 
-    ;; 84µs => 100µs
+    ;; 84µs
+    ;; 100µs
+    ;; 110µs (context-api)
     (bench!
       "sieppari: delay (async)"
       (let [p (promise)]
@@ -181,6 +190,7 @@
     ;; 84µs
     ;; 62µs (chain'-)
     ;; 89µs
+    ;; 90µs (context-api)
     (bench!
       "sieppari: deferred (sync)"
       (s/execute s-deferred-chain {}))
@@ -188,6 +198,7 @@
     ;; 84µs
     ;; 84µs (chain'-)
     ;; 150µs
+    ;; 110µs (context-api)
     (bench!
       "sieppari: deferred (async)"
       (let [p (promise)]
@@ -197,6 +208,7 @@
     ;; 36µs
     ;; 3.8µs
     ;; 5.4µs
+    ;; 3.8µs (context-api)
     (bench!
       "sieppari: promesa (sync)"
       (s/execute s-promesa-chain {}))
@@ -204,6 +216,7 @@
     ;; 38µs
     ;; 4.0µs
     ;; 5.3µs
+    ;; 4.0µs (context-api)
     (bench!
       "sieppari: promesa (async)"
       (let [p (promise)]
@@ -227,20 +240,20 @@
           (s/execute interceptors {} p identity)
           @p)))
 
-    ;; 1.8µs => 4.6µs
-    ;; 1.7µs => 4.6µs
+    ;; 1.8µs => 4.6µs => 1.8µs
+    ;; 1.7µs => 4.6µs => 1.8µs
     "identity"
 
-    ;; 93µs
-    ;; 20µs
+    ;; 93µs => 100µs
+    ;; 20µs => 18µs
     "deferred"
 
-    ;; 54µs
-    ;; 20µs
+    ;; 54µs => 73µs
+    ;; 20µs => 17µs
     "core.async"
 
-    ;; 40µs => 4.0µs => 4.4µs
-    ;; 19µs => 2.5µs => 5.0µs
+    ;; 40µs => 4.0µs => 4.4µs => 3.9µs
+    ;; 19µs => 2.5µs => 5.0µs => 2.0µs
     "promesa"))
 
 (defn -main [& _]

--- a/examples/example/perf_testing.clj
+++ b/examples/example/perf_testing.clj
@@ -228,9 +228,9 @@
   (doseq [[name chain] [[(str "homogeneous queue of " n) create-s-chain]
                         [(str "queue of " (dec n) " sync + 1 async step") create-s-mixed-chain]]
           :let [_ (suite name)]
-          [name interceptor] [["identity" identity]
-                              ["deferred" deferred-interceptor]
-                              ["core.async" async-interceptor]
+          [name interceptor] [["identity" sync-interceptor]
+                              #_["deferred" deferred-interceptor]
+                              #_["core.async" async-interceptor]
                               ["promesa" promesa-interceptor]]]
 
     (let [interceptors (chain n interceptor)]
@@ -240,8 +240,8 @@
           (s/execute interceptors {} p identity)
           @p)))
 
-    ;; 1.8µs => 4.6µs => 1.8µs
-    ;; 1.7µs => 4.6µs => 1.8µs
+    ;; 1.8µs => 4.6µs => 1.8µs => 1.3µs
+    ;; 1.7µs => 4.6µs => 1.8µs => 1.4µs
     "identity"
 
     ;; 93µs => 100µs
@@ -252,8 +252,8 @@
     ;; 20µs => 17µs
     "core.async"
 
-    ;; 40µs => 4.0µs => 4.4µs => 3.9µs
-    ;; 19µs => 2.5µs => 5.0µs => 2.0µs
+    ;; 40µs => 4.0µs => 4.4µs => 3.9µs => 3.3µs
+    ;; 19µs => 2.5µs => 5.0µs => 2.0µs => 1.8µs
     "promesa"))
 
 (defn middleware-comp [n]

--- a/examples/example/perf_testing.clj
+++ b/examples/example/perf_testing.clj
@@ -137,11 +137,13 @@
         @p))
 
     ;; 1.3µs
+    ;; 2.1µs
     (bench!
       "sieppari: sync (sync)"
       (s/execute s-sync-chain {}))
 
     ;; 1.3µs
+    ;; 2,5µs
     (bench!
       "sieppari: sync (async)"
       (let [p (promise)]
@@ -149,11 +151,13 @@
         @p))
 
     ;; 61µs
+    ;; 69µs
     (bench!
       "sieppari: core.async (sync)"
       (s/execute s-async-chain {}))
 
     ;; 60µs
+    ;; 65µs
     (bench!
       "sieppari: core.async (async)"
       (let [p (promise)]
@@ -167,7 +171,7 @@
         (s/execute s-future-chain {} p identity)
         @p))
 
-    ;; 84µs
+    ;; 84µs => 100µs
     (bench!
       "sieppari: delay (async)"
       (let [p (promise)]
@@ -176,12 +180,14 @@
 
     ;; 84µs
     ;; 62µs (chain'-)
+    ;; 89µs
     (bench!
       "sieppari: deferred (sync)"
       (s/execute s-deferred-chain {}))
 
     ;; 84µs
     ;; 84µs (chain'-)
+    ;; 150µs
     (bench!
       "sieppari: deferred (async)"
       (let [p (promise)]
@@ -190,18 +196,19 @@
 
     ;; 36µs
     ;; 3.8µs
+    ;; 5.4µs
     (bench!
       "sieppari: promesa (sync)"
       (s/execute s-promesa-chain {}))
 
     ;; 38µs
     ;; 4.0µs
+    ;; 5.3µs
     (bench!
       "sieppari: promesa (async)"
       (let [p (promise)]
         (s/execute s-promesa-chain {} p identity)
-        @p))
-    ))
+        @p))))
 
 (defn one-async-in-sync-pipeline-test [n]
 
@@ -220,8 +227,8 @@
           (s/execute interceptors {} p identity)
           @p)))
 
-    ;; 1.8µs
-    ;; 1.7µs
+    ;; 1.8µs => 4.6µs
+    ;; 1.7µs => 4.6µs
     "identity"
 
     ;; 93µs
@@ -232,8 +239,8 @@
     ;; 20µs
     "core.async"
 
-    ;; 40µs => 4.0µs
-    ;; 19µs => 2.5µs
+    ;; 40µs => 4.0µs => 4.4µs
+    ;; 19µs => 2.5µs => 5.0µs
     "promesa"))
 
 (defn -main [& _]

--- a/examples/example/perf_testing.clj
+++ b/examples/example/perf_testing.clj
@@ -256,13 +256,23 @@
     ;; 19µs => 2.5µs => 5.0µs => 2.0µs
     "promesa"))
 
+(defn middleware-comp [n]
+  (let [chain (apply comp (repeat n identity))]
+
+    ;; 105ns
+    (bench!
+      "comp"
+      (chain {}))))
+
 (defn -main [& _]
   (run-simple-perf-test 10)
-  (one-async-in-sync-pipeline-test 10))
+  (one-async-in-sync-pipeline-test 10)
+  (middleware-comp 10))
 
 (comment
   (run-simple-perf-test 10)
   (one-async-in-sync-pipeline-test 10)
+  (middleware-comp 10)
   (-main)
 
   (do

--- a/examples/example/perf_testing.clj
+++ b/examples/example/perf_testing.clj
@@ -250,4 +250,16 @@
 (comment
   (run-simple-perf-test 10)
   (one-async-in-sync-pipeline-test 10)
-  (-main))
+  (-main)
+
+  (do
+    (require '[clj-async-profiler.core :as prof])
+    (prof/serve-files 8080))
+
+  (time
+    (prof/profile
+      (let [interceptors (create-s-chain 10 identity)]
+        (dotimes [_ 3000000]
+          (let [p (promise)]
+            (s/execute interceptors {} p identity)
+            @p))))))

--- a/project.clj
+++ b/project.clj
@@ -21,6 +21,7 @@
                                        [org.clojure/tools.namespace "1.0.0"]
                                        ;; Perf testing:
                                        [criterium "0.4.5"]
+                                       [com.clojure-goes-fast/clj-async-profiler "0.5.0-SNAPSHOT"]
                                        [io.pedestal/pedestal.interceptor "0.5.7"]
                                        [org.slf4j/slf4j-nop "1.7.30"]]}
 

--- a/src/sieppari/core.cljc
+++ b/src/sieppari/core.cljc
@@ -5,7 +5,8 @@
             #?(:cljs [goog.iter :as iter]))
   #?(:clj (:import (java.util Iterator))))
 
-(defrecord Context [error queue stack on-complete on-error])
+(defrecord RawContext [error queue stack on-complete on-error])
+(defrecord Context [request response error queue stack on-complete on-error])
 
 (defn- try-f [ctx f]
   (if f
@@ -24,7 +25,7 @@
     (let [^Iterator it (:stack ctx)]
       (if (.hasNext it)
         (let [stage (if (:error ctx) :error :leave)
-              f     (-> it .next stage)]
+              f (-> it .next stage)]
           (recur (try-f ctx f)))
         ctx))))
 
@@ -35,8 +36,8 @@
 (defn- enter [ctx]
   (if (a/async? ctx)
     (a/continue ctx enter)
-    (let [queue       (:queue ctx)
-          stack       (:stack ctx)
+    (let [queue (:queue ctx)
+          stack (:stack ctx)
           interceptor (peek queue)]
       (if (or (not interceptor) (:error ctx))
         (assoc ctx :stack (iter stack))
@@ -58,17 +59,20 @@
 (defn- deliver-result [ctx get-result]
   (if (a/async? ctx)
     (a/continue ctx #(deliver-result % get-result))
-    (let [error    (:error ctx)
-          result   (or error (get-result ctx))
+    (let [error (:error ctx)
+          result (or error (get-result ctx))
           callback (if error :on-error :on-complete)
-          f        (callback ctx identity)]
+          f (callback ctx identity)]
       (f result))))
 
-(defn- context [m]
-  (map->Context m))
+(defn- context
+  ([request queue]
+   (new Context request nil nil queue nil nil nil))
+  ([request queue on-complete on-error]
+   (new Context request nil nil queue nil on-complete on-error)))
 
 (defn- remove-context-keys [ctx]
-  (dissoc ctx :error :queue :stack :on-complete :on-error))
+  (str ctx) (dissoc ctx :error :queue :stack :on-complete :on-error))
 
 ;;
 ;; Public API:
@@ -83,7 +87,7 @@
   ([interceptors ctx on-complete on-error get-result]
    (if-let [queue (q/into-queue interceptors)]
      (-> (assoc ctx :queue queue :on-complete on-complete :on-error on-error)
-         (context)
+         (map->RawContext)
          (enter)
          (leave)
          (deliver-result get-result))
@@ -98,7 +102,7 @@
      ([interceptors ctx get-result]
       (when-let [queue (q/into-queue interceptors)]
         (-> (assoc ctx :queue queue)
-            (context)
+            (map->RawContext)
             (enter)
             (leave)
             (await-result get-result))))))
@@ -108,7 +112,19 @@
    '([interceptors request]
      [interceptors request on-complete on-error])}
   ([interceptors request on-complete on-error]
-   (execute-context interceptors {:request request} on-complete on-error :response))
+   (if-let [queue (q/into-queue interceptors)]
+     (-> (context request queue on-complete on-error)
+         (enter)
+         (leave)
+         (deliver-result :response))
+     ;; It is always necessary to call on-complete or the computation would not
+     ;; keep going.
+     (on-complete nil))
+   nil)
   #?(:clj
      ([interceptors request]
-      (execute-context interceptors {:request request} :response))))
+      (when-let [queue (q/into-queue interceptors)]
+        (-> (context request queue)
+            (enter)
+            (leave)
+            (await-result :response))))))

--- a/src/sieppari/core.cljc
+++ b/src/sieppari/core.cljc
@@ -72,7 +72,7 @@
    (new RequestResponseContext request nil nil queue nil on-complete on-error)))
 
 (defn- remove-context-keys [ctx]
-  (str ctx) (dissoc ctx :error :queue :stack :on-complete :on-error))
+  (dissoc ctx :error :queue :stack :on-complete :on-error))
 
 ;;
 ;; Public API:


### PR DESCRIPTION
* Use separate paths with `execute` and `execute-context` not to get perf penalty
* more perf-tests, polished README