### PR TITLE
For discussion. Another async context protocol

### DIFF
--- a/examples/example/perf_testing.clj
+++ b/examples/example/perf_testing.clj
@@ -120,6 +120,7 @@
     (suite (str "queue of " n))
 
     ;; 8.2µs
+    ;;baseline 11.03µs
     (bench!
       "pedestal: sync"
       (->> p-sync-chain
@@ -128,6 +129,7 @@
            :response))
 
     ;; 99µs
+    ;;baseline 124.10µs
     (bench!
       "pedestal: core.async"
       (let [p (promise)]
@@ -137,11 +139,15 @@
         @p))
 
     ;; 1.3µs
+    ; baseline 3.12µs
+    ;3.4
     (bench!
       "sieppari: sync (sync)"
       (s/execute s-sync-chain {}))
 
     ;; 1.3µs
+    ;baseline 3.46µs
+    ;3.6
     (bench!
       "sieppari: sync (async)"
       (let [p (promise)]
@@ -149,11 +155,15 @@
         @p))
 
     ;; 61µs
+    ;;baseline  78.13µs
+    ;;59.90µs
     (bench!
       "sieppari: core.async (sync)"
       (s/execute s-async-chain {}))
 
     ;; 60µs
+    ;;baseline  89.38µs
+    ;;59.18µs
     (bench!
       "sieppari: core.async (async)"
       (let [p (promise)]
@@ -161,6 +171,8 @@
         @p))
 
     ;; 140µs
+    ;baseline 186.33µs
+    ;68.83µs
     (bench!
       "sieppari: future (async)"
       (let [p (promise)]
@@ -168,6 +180,8 @@
         @p))
 
     ;; 84µs
+    ;baseline  171.79µs
+    ; 27.79µs
     (bench!
       "sieppari: delay (async)"
       (let [p (promise)]
@@ -176,12 +190,16 @@
 
     ;; 84µs
     ;; 62µs (chain'-)
+    ;;baseline   111.90µs
+    ;;  28.77µs
     (bench!
       "sieppari: deferred (sync)"
       (s/execute s-deferred-chain {}))
 
     ;; 84µs
     ;; 84µs (chain'-)
+    ;;baseline 131.95µs
+    ; 26.16µs
     (bench!
       "sieppari: deferred (async)"
       (let [p (promise)]
@@ -190,12 +208,15 @@
 
     ;; 36µs
     ;; 3.8µs
+    ;;baseline  5.67µs
     (bench!
       "sieppari: promesa (sync)"
       (s/execute s-promesa-chain {}))
 
     ;; 38µs
     ;; 4.0µs
+    ;baseline 5.13µs
+    ;4.72µs
     (bench!
       "sieppari: promesa (async)"
       (let [p (promise)]
@@ -222,18 +243,26 @@
 
     ;; 1.8µs
     ;; 1.7µs
+    ;baseline  5.75µs
+    ;6.17µs
     "identity"
 
     ;; 93µs
     ;; 20µs
+    ;baseline  29.13µs
+    ;18.25µs
     "deferred"
 
     ;; 54µs
     ;; 20µs
+    ;baseline 32.04µs
+    ;22.34µs
     "core.async"
 
     ;; 40µs => 4.0µs
     ;; 19µs => 2.5µs
+    ;baseline 6.02µs
+    ; 5.96µs
     "promesa"))
 
 (defn -main [& _]

--- a/project.clj
+++ b/project.clj
@@ -26,6 +26,7 @@
 
              ;; needed because of https://github.com/lambdaisland/kaocha-cljs#known-issues
              :test-cljs {:source-paths ["test/cljc" "test/cljs"]}
+             :test {:source-paths ["test/cljc" "test/clj"]}
 
              :dev [:dev-deps {:source-paths ["dev"]}]
              :examples {:source-paths ["examples"]}

--- a/src/sieppari/async.cljc
+++ b/src/sieppari/async.cljc
@@ -7,8 +7,7 @@
 
 (defprotocol AsyncContext
   (async? [t])
-  (continue [t f])
-  (catch [c f])
+  (continue [t old-ctx f])
   #?(:clj (await [t])))
 
 #?(:clj
@@ -21,40 +20,44 @@
    (extend-protocol AsyncContext
      Object
      (async? [_] false)
-     (continue [t f] (f t))
+     (continue [t old-ctx f] (f t))
      (await [t] t)))
 
 #?(:cljs
    (extend-protocol AsyncContext
      default
      (async? [_] false)
-     (continue [t f] (f t))))
+     (continue [t old-ctx f] (f t))))
+
+(extend-protocol AsyncContext
+   nil
+  (async? [_] false))
 
 #?(:clj
    (extend-protocol AsyncContext
      clojure.lang.IDeref
      (async? [_] true)
-     (continue [c f] (future (f @c)))
-     (catch [c f] (future (let [c @c]
-                            (if (exception? c) (f c) c))))
+     (continue [c old-ctx f]
+       (future
+         (let [c (try @c
+                      (catch Exception e
+                        (assoc old-ctx :error e)))]
+           (f c))))
      (await [c] @c)))
 
 #?(:clj
    (extend-protocol AsyncContext
      CompletionStage
      (async? [_] true)
-     (continue [this f]
+     (continue [this old-ctx f]
+       (letfn [(handler [e]
+                 (if (instance? CompletionException e)
+                   (f (assoc old-ctx :error (.getCause ^Exception e)))
+                   (f (assoc old-ctx :error e))))]
+         (.exceptionally ^CompletionStage this
+                         ^Function (->FunctionWrapper handler)))
        (.thenApply ^CompletionStage this
                    ^Function (->FunctionWrapper f)))
-
-     (catch [this f]
-       (letfn [(handler [e]
-                  (if (instance? CompletionException e)
-                   (f (.getCause ^Exception e))
-                   (f e)))]
-         (.exceptionally ^CompletionStage this
-                         ^Function (->FunctionWrapper handler))))
-
      (await [this]
        (deref this))))
 
@@ -62,5 +65,6 @@
    (extend-protocol AsyncContext
      js/Promise
      (async? [_] true)
-     (continue [t f] (.then t f))
-     (catch [t f] (.catch t f))))
+     (continue [t old-ctx f]
+       (.catch t (fn [e] (f (assoc old-ctx :error e))))
+       (.then t f))))

--- a/src/sieppari/async/core_async.cljc
+++ b/src/sieppari/async/core_async.cljc
@@ -9,7 +9,10 @@
   #?(:clj clojure.core.async.impl.protocols.Channel
      :cljs cljs.core.async.impl.channels/ManyToManyChannel)
   (async? [_] true)
-  (continue [c f] (go (f (cca/<! c))))
-  (catch [c f] (go (let [c (cca/<! c)]
-                     (if (exception? c) (f c) c))))
+  (continue [c old-ctx f]
+    (cca/take! c
+               (fn [x]
+                 (if (exception? x)
+                   (f (assoc old-ctx :error x))
+                   (f x)))))
   #?(:clj (await [c] (<!! c))))

--- a/src/sieppari/core.cljc
+++ b/src/sieppari/core.cljc
@@ -2,39 +2,71 @@
   #?(:cljs (:refer-clojure :exclude [iter]))
   (:require [sieppari.queue :as q]
             [sieppari.async :as a]
+            [sieppari.util :refer [exception?]]
+            [sieppari.interceptor :as inter]
             #?(:cljs [goog.iter :as iter]))
   #?(:clj (:import (java.util Iterator))))
 
-(defrecord Context [error queue stack on-complete on-error])
+(defrecord Context [error queue stack on-complete on-error async go-async final-transform])
 
-(defn- try-f [ctx f]
+(deftype box [a])
+(defn box? [a]
+  (instance? box a))
+
+(defn unbox [a]
+  (if (box? a)
+    (.-a a)
+    a))
+
+(defn context? [x]
+  (instance? Context x))
+
+(declare enter-leave handle-async)
+
+(defn- try-f [ctx f stage]
   (if f
     (try
       (let [ctx* (f ctx)]
         (if (a/async? ctx*)
-          (a/catch ctx* (fn [e] (assoc ctx :error e)))
-          ctx*))
+          (handle-async ctx* ctx stage)
+          (unbox ctx*)))
       (catch #?(:clj Exception :cljs :default) e
+        #_(tap> :error)
+        #_(tap> (pr-str e))
         (assoc ctx :error e)))
     ctx))
 
+(defn finish [ctx]
+  (if (context? ctx)
+    (let [error (:error ctx)]
+      (if error
+        (do
+          (when-some [on-error (:on-error ctx )]
+            (on-error ctx))
+            ctx)
+        (let [final-transform (:final-transform ctx identity)
+              final-value (final-transform ctx)]
+          (when-some [on-complete (:on-complete ctx )]
+            (on-complete final-value))
+          final-value)))
+    ctx))
+
 (defn- leave [ctx]
-  (if (a/async? ctx)
-    (a/continue ctx leave)
+  (if (context? ctx)
     (let [^Iterator it (:stack ctx)]
       (if (.hasNext it)
         (let [stage (if (:error ctx) :error :leave)
               f     (-> it .next stage)]
-          (recur (try-f ctx f)))
-        ctx))))
+          (recur (try-f ctx f leave)))
+        (finish ctx)))
+    ctx))
 
 (defn- iter [v]
   #?(:clj  (clojure.lang.RT/iter v)
      :cljs (cljs.core/iter v)))
 
 (defn- enter [ctx]
-  (if (a/async? ctx)
-    (a/continue ctx enter)
+  (if (context? ctx)
     (let [queue       (:queue ctx)
           stack       (:stack ctx)
           interceptor (peek queue)]
@@ -45,30 +77,70 @@
                    (assoc :stack #?(:clj  (conj stack interceptor)
                                     :cljs (doto (or stack (array))
                                             (.unshift interceptor))))
-                   (try-f (:enter interceptor))))))))
+                   (try-f (:enter interceptor) enter-leave)))))
+    (do
+      #_(tap> :nocontext-enter)
+      #_(tap> ctx)
+      #_(tap> :nocontext-enter-out)
+      ctx)))
 
 #?(:clj
-   (defn- await-result [ctx get-result]
+   (defn- await-result [ctx]
+     #_(tap> :await)
+     #_(tap> (a/async? ctx))
+     #_(tap> ctx)
      (if (a/async? ctx)
-       (recur (a/await ctx) get-result)
+       (recur (a/await ctx) )
        (if-let [error (:error ctx)]
          (throw error)
-         (get-result ctx)))))
+         ctx))))
 
-(defn- deliver-result [ctx get-result]
-  (if (a/async? ctx)
-    (a/continue ctx #(deliver-result % get-result))
-    (let [error    (:error ctx)
-          result   (or error (get-result ctx))
-          callback (if error :on-error :on-complete)
-          f        (callback ctx identity)]
-      (f result))))
+(defn enter-leave [ctx]
+  #_(tap> :enterleave)
+  ;#_(tap> ctx)
+  (-> ctx
+      enter
+      ;(doto tap>)
+      leave))
+(add-tap prn)
+(defn handle-async [ctx old-ctx stage]
+  (if (:async old-ctx)
+    (do (a/continue ctx old-ctx stage)
+        nil)
+    (if-some [go-async (:go-async old-ctx)]
+      (let [async-data (go-async stage)
+            go-async!  (nth async-data 1)]
+        (a/continue ctx old-ctx go-async!)
+        (nth async-data 0))
+      (do (a/continue ctx old-ctx stage)
+          nil))))
+
+(defn wrap-callback [f p]
+  (if f
+    (fn [r] #_(tap> :deliver)  (clojure.core/deliver p r) (f r))
+    (fn [r] #_(tap> :deliver) (clojure.core/deliver p r))))
+#?(:clj
+   (defn- go-async-promise [stage]
+     (let [p (promise)]
+       [p (fn [ctx]
+            #_(tap> :go-async-promise)
+            #_(tap> ctx)
+            #_(tap> stage)
+            (-> ctx
+                (assoc :on-complete
+                       (wrap-callback (:on-complete ctx) p)
+                       :on-error
+                       (wrap-callback (:on-error ctx) p)
+                       :go-async nil
+                       :async true)
+                stage))])))
 
 (defn- context [m]
   (map->Context m))
 
 (defn- remove-context-keys [ctx]
-  (dissoc ctx :error :queue :stack :on-complete :on-error))
+  (dissoc ctx :error :queue :stack :on-complete :on-error
+          :async  :go-async :final-transform))
 
 ;;
 ;; Public API:
@@ -82,11 +154,10 @@
    (execute-context interceptors ctx on-complete on-error remove-context-keys))
   ([interceptors ctx on-complete on-error get-result]
    (if-let [queue (q/into-queue interceptors)]
-     (-> (assoc ctx :queue queue :on-complete on-complete :on-error on-error)
+     (-> (assoc ctx :queue queue :on-complete on-complete :on-error on-error
+                    :final-transform get-result)
          (context)
-         (enter)
-         (leave)
-         (deliver-result get-result))
+         (enter-leave))
      ;; It is always necessary to call on-complete or the computation would not
      ;; keep going.
      (on-complete nil))
@@ -97,11 +168,10 @@
   #?(:clj
      ([interceptors ctx get-result]
       (when-let [queue (q/into-queue interceptors)]
-        (-> (assoc ctx :queue queue)
+        (-> (assoc ctx :queue queue :final-transform get-result :go-async go-async-promise)
             (context)
-            (enter)
-            (leave)
-            (await-result get-result))))))
+            (enter-leave)
+            (await-result))))))
 
 (defn execute
   {:arglists
@@ -112,3 +182,46 @@
   #?(:clj
      ([interceptors request]
       (execute-context interceptors {:request request} :response))))
+
+
+(defn- async-set-result [ctx continue]
+  (fn [response]
+    #_(tap> :async-response)
+    #_(tap> response)
+    #_(tap> ctx)
+    (continue
+      (if (context? response)
+        response
+        (assoc ctx
+          :response
+          response)))))
+
+(defn handle-async-handler [response old-ctx stage]
+  (if (:async old-ctx)
+    (do (a/continue response old-ctx (async-set-result old-ctx stage))
+        nil)
+    (if-some [go-async (:go-async old-ctx)]
+      (let [async-data (go-async stage)
+            go-async!  (nth async-data 1)]
+        (a/continue response old-ctx (async-set-result old-ctx go-async!))
+        (->box (nth async-data 0)))
+      (do (a/continue response old-ctx (async-set-result old-ctx stage))
+          nil))))
+
+(defn- set-result [ctx response]
+  #_(tap> :response)
+  #_(tap> response)
+  ;#_(tap> ctx)
+  (if (and (some? response) (a/async? response))
+    (handle-async-handler response ctx enter-leave)
+    (assoc ctx
+      (if (exception? response) :error :response)
+      response)))
+(extend-protocol inter/IntoInterceptor
+  ;; Function -> Handler interceptor:
+  #?(:clj clojure.lang.Fn
+     :cljs function)
+  (into-interceptor [handler]
+    (inter/into-interceptor {:enter (fn [ctx]
+                                #_(tap> :enter-handler)
+                                (set-result ctx (handler (:request ctx))))})))

--- a/src/sieppari/interceptor.cljc
+++ b/src/sieppari/interceptor.cljc
@@ -7,13 +7,6 @@
 (defprotocol IntoInterceptor
   (into-interceptor [t] "Given a value, produce an Interceptor Record."))
 
-(defn- set-result [ctx response]
-  (if (and (some? response) (a/async? response))
-    (a/continue response (partial set-result ctx))
-    (assoc ctx
-           (if (exception? response) :error :response)
-           response)))
-
 (extend-protocol IntoInterceptor
   ;; Map -> Interceptor:
   #?(:clj clojure.lang.IPersistentMap
@@ -24,13 +17,6 @@
   #?(:cljs cljs.core.PersistentArrayMap)
   (into-interceptor [interceptor-map]
     (map->Interceptor interceptor-map))
-
-  ;; Function -> Handler interceptor:
-  #?(:clj clojure.lang.Fn
-     :cljs function)
-  (into-interceptor [handler]
-    (into-interceptor {:enter (fn [ctx]
-                                (set-result ctx (handler (:request ctx))))}))
 
   ;; Vector -> Interceptor, first element is a function to create
   ;; the interceptor, rest are arguments for it:

--- a/test/clj/sieppari/async/manifold_test.clj
+++ b/test/clj/sieppari/async/manifold_test.clj
@@ -14,7 +14,7 @@
         d (d/deferred)]
     (future
       (d/success! d "foo"))
-    (as/continue d (partial deliver p))
+    (as/continue d {} (partial deliver p))
     (fact
       @p =eventually=> "foo")))
 
@@ -23,7 +23,8 @@
         d (d/deferred)]
     (future
       (d/success! d "foo"))
-    (as/catch (as/continue d (partial deliver p))
+    (as/continue (as/continue d {} (partial deliver p))
+                 {}
               (fn [_] (deliver p "barf")))
     (fact
       @p =eventually=> "foo"))
@@ -32,7 +33,7 @@
         d (d/deferred)]
     (future
       (d/error! d (Exception. "fubar")))
-    (as/catch d (fn [_] (deliver p "foo")))
+    (as/continue d {} (fn [_] (deliver p "foo")))
     (fact
       @p =eventually=> "foo")))
 

--- a/test/clj/sieppari/core_async_test.clj
+++ b/test/clj/sieppari/core_async_test.clj
@@ -18,6 +18,8 @@
 
 (defn make-logging-handler [log]
   (fn [request]
+    #_(tap> :handler)
+    #_(tap> request)
     (swap! log conj [:handler])
     request))
 

--- a/test/clj/sieppari/core_test.clj
+++ b/test/clj/sieppari/core_test.clj
@@ -4,8 +4,10 @@
             [sieppari.core :as s]
             [clojure.core.async :as a]))
 
-(def try-f #'s/try-f)
+(def try-f-inine #'s/try-f)
 
+(defn try-f [a b]
+  (try-f-inine a b identity))
 (deftest try-f-test
   (fact
     (try-f {} nil)
@@ -20,7 +22,9 @@
     @(try-f {} (fn [_] (future (ex-info "oh no" {}))))
     =eventually-in=> {:error (ex-info? "oh no" {})}))
 
-(def await-result #'s/await-result)
+(def inlineawait #'s/await-result)
+(defn await-result [in pf]
+  (pf (inlineawait in)))
 
 (def error (RuntimeException. "kosh"))
 
@@ -44,11 +48,11 @@
     (await-result (future {:error error}) :response) =throws=> error
     (await-result (future (future {:error error})) :response) =throws=> error))
 
-(def deliver-result #'s/deliver-result)
+#_(def deliver-result #'s/deliver-result)
 
 (defn fail! [_] (throw (ex-info "should never get here" {})))
 
-(deftest deliver-result-test
+#_(deftest deliver-result-test
   (let [p (promise)]
     (deliver-result {:response :r
                      :on-complete p

--- a/test/clj/sieppari/manifold_test.clj
+++ b/test/clj/sieppari/manifold_test.clj
@@ -191,7 +191,7 @@
            (make-logging-interceptor log :c)
            (fn [_]
              (swap! log conj [:handler])
-             (d/success-deferred error))]
+             (d/error-deferred error))]
           (sc/execute request))
       =throws=> error)
     (fact
@@ -217,7 +217,7 @@
            (make-logging-interceptor log :c)
            (fn [_]
              (swap! log conj [:handler])
-             (d/success-deferred error))]
+             (d/error-deferred error))]
           (sc/execute request))
       => :fixed-by-b)
     (fact

--- a/test/cljc/sieppari/async/core_async_test.cljc
+++ b/test/cljc/sieppari/async/core_async_test.cljc
@@ -10,12 +10,13 @@
 #?(:clj
    (deftest core-async-continue-clj-promise-test
      (let [respond (promise)]
-       (as/continue (a/go "foo") (partial deliver respond))
+       (as/continue (a/go "foo") {} (partial deliver respond))
        (is (= "foo" @respond))))
    :cljs
    (deftest core-async-continue-cljs-callback-test
      (async done
        (is (as/continue (a/go "foo")
+                        {}
                         (fn [response]
                           (is (= "foo" response))
                           (done)))))))
@@ -23,13 +24,15 @@
 #?(:clj
    (deftest core-async-catch-clj-promise-test
      (let [respond (promise)]
-       (as/catch (a/go (Exception. "fubar")) (fn [_] (deliver respond "foo")))
+       (as/continue (a/go (Exception. "fubar")) {} (fn [_] (deliver respond "foo")))
        (is (= "foo" @respond))))
    :cljs
    (deftest core-async-catch-cljs-callback-test
      (async done
-       (is (as/continue (as/catch (a/go (js/Error. "fubar"))
+       (is (as/continue (as/continue (a/go (js/Error. "fubar"))
+                                     {}
                                   (fn [_] "foo"))
+                        {}
                         (fn [response]
                           (is (= "foo" response))
                           (done)))))))

--- a/test/cljc/sieppari/async/promesa_test.cljc
+++ b/test/cljc/sieppari/async/promesa_test.cljc
@@ -13,7 +13,7 @@
            p (p/create
                (fn [resolve _]
                  (px/schedule! 10 #(resolve "foo"))))]
-       (as/continue p respond)
+       (as/continue p {} respond)
        (is (= @respond "foo"))))
    :cljs
    (deftest core-async-continue-cljs-callback-test
@@ -21,7 +21,7 @@
                (fn [resolve _]
                  (px/schedule! 10 #(resolve "foo"))))]
        (async done
-         (is (as/continue p (fn [response]
+         (is (as/continue p {} (fn [response]
                               (is (= "foo" response))
                               (done))))))))
 
@@ -31,7 +31,7 @@
            p (p/create
                (fn [_ reject]
                  (px/schedule! 10 #(reject (Exception. "fubar")))))]
-       (as/catch p (fn [_] (respond "foo")))
+       (as/continue p  {} (fn [_] (respond "foo")))
        (is (= @respond "foo"))))
    :cljs
    (deftest core-async-catch-cljs-callback-test
@@ -39,7 +39,8 @@
                (fn [_ reject]
                  (px/schedule! 10 #(reject (js/Error. "fubar")))))]
        (async done
-         (is (as/continue (as/catch p (fn [_] "foo"))
+         (is (as/continue (as/continue p  {} (fn [_] "foo"))
+                          {}
                           (fn [response]
                             (is (= "foo" response))
                             (done))))))))


### PR DESCRIPTION
This is a demonstration not to merge.
I did a refactor of the AsyncContext protocol.
dereffables and deferred run between 1/3-1/5 the time in `perf_testing.clj`
core.async async benchmark got a more modest 34% reduction in runtime. 

The previous shape of the AsyncContext protocol required much communication with the thread that started the pipeline. The goal of this branch was to explore letting the main thread go sooner and minimizing context switches as we pass the computation from one async context to another.

I took care to ensure that I was not blocking the thread when I could help it, but there could still be issues with users blocking inside interceptor functions. 

I left 4 errors and 18 failures that are mostly caused by differences if implementation function boundaries. I got just enough tests working to have a bit of confidence of the outcome. The handler interceptor caused most of the ugliness of branch.

The previous shape required much communication with the thread that started the pipeline. 

I made 3 main changes:

1.   I brought back a go-async handler like [pedestal](https://github.com/pedestal/pedestal/blob/master/interceptor/src/io/pedestal/interceptor/chain.clj#L102) had. This allowed me to free the thread that started the pipeline faster. I used a clojure.core/promise to emulate the blocking on the calls that required it. 
2.  I combined the catch and continue into continue.In order to do this I had to pass in the previous context so the exceptions could be `assoc`ed on.
3.  I used more primitive functions on `core.async` and `manifold`. In `manifold` I made a fastpath if the `deferred` was realized. This could be generalized to other AsyncContext.

I think the work in 3 could be adapted without such significant changes.