### PR TITLE
fail on unsupported context classes

### DIFF
--- a/src/sieppari/context.cljc
+++ b/src/sieppari/context.cljc
@@ -1,6 +1,28 @@
 (ns sieppari.context
   (:require [sieppari.queue :as q]))
 
+(defprotocol Context
+  (context? [this]))
+
+(extend-protocol Context
+  #?(:clj  clojure.lang.PersistentHashMap
+     :cljs cljs.core.PersistentHashMap)
+  (context? [_] true)
+
+  #?(:clj  clojure.lang.PersistentArrayMap
+     :cljs cljs.core.PersistentArrayMap)
+  (context? [_] true))
+
+#?(:clj
+   (extend-protocol Context
+     Object
+     (context? [_] false)))
+
+#?(:cljs
+   (extend-protocol Context
+     default
+     (context? [_] false)))
+
 (defn terminate
   "Removes all remaining interceptors from context's execution queue.
   This effectively short-circuits execution of Interceptors' :enter

--- a/src/sieppari/core.cljc
+++ b/src/sieppari/core.cljc
@@ -2,13 +2,19 @@
   #?(:cljs (:refer-clojure :exclude [iter]))
   (:require [sieppari.queue :as q]
             [sieppari.async :as a]
+            [sieppari.context :as c]
             #?(:cljs [goog.iter :as iter]))
   #?(:clj (:import (java.util Iterator))))
 
-(defrecord Context [error queue stack on-complete on-error])
-(defrecord RequestResponseContext [request response error queue stack on-complete on-error])
+(defrecord Context [error queue stack on-complete on-error]
+  c/Context
+  (context? [_] true))
 
-(defn- try-f [ctx f]
+(defrecord RequestResponseContext [request response error queue stack on-complete on-error]
+  c/Context
+  (context? [_] true))
+
+(defn- -try [ctx f]
   (if f
     (try
       (let [ctx* (f ctx)]
@@ -19,34 +25,42 @@
         (assoc ctx :error e)))
     ctx))
 
-(defn- leave [ctx]
-  (if (a/async? ctx)
-    (a/continue ctx leave)
-    (let [^Iterator it (:stack ctx)]
-      (if (.hasNext it)
-        (let [stage (if (:error ctx) :error :leave)
-              f (-> it .next stage)]
-          (recur (try-f ctx f)))
-        ctx))))
-
-(defn- iter [v]
+(defn- -iter [v]
   #?(:clj  (clojure.lang.RT/iter v)
      :cljs (cljs.core/iter v)))
 
+(defn- -invalid-context-type! [ctx stage]
+  (throw
+    (ex-info
+      (str "Unsupported Context on " stage" - " ctx)
+      {:ctx ctx})))
+
+(defn- leave [ctx]
+  (cond
+    (a/async? ctx) (a/continue ctx leave)
+    (c/context? ctx) (let [^Iterator it (:stack ctx)]
+                       (if (.hasNext it)
+                         (let [stage (if (:error ctx) :error :leave)
+                               f (-> it .next stage)]
+                           (recur (-try ctx f)))
+                         ctx))
+    :else (-invalid-context-type! ctx :leave)))
+
 (defn- enter [ctx]
-  (if (a/async? ctx)
-    (a/continue ctx enter)
-    (let [queue (:queue ctx)
-          stack (:stack ctx)
-          interceptor (peek queue)]
-      (if (or (not interceptor) (:error ctx))
-        (assoc ctx :stack (iter stack))
-        (recur (-> ctx
-                   (assoc :queue (pop queue))
-                   (assoc :stack #?(:clj  (conj stack interceptor)
-                                    :cljs (doto (or stack (array))
-                                            (.unshift interceptor))))
-                   (try-f (:enter interceptor))))))))
+  (cond
+    (a/async? ctx) (a/continue ctx enter)
+    (c/context? ctx) (let [queue (:queue ctx)
+                           stack (:stack ctx)
+                           interceptor (peek queue)]
+                       (if (or (not interceptor) (:error ctx))
+                         (assoc ctx :stack (-iter stack))
+                         (recur (-> ctx
+                                    (assoc :queue (pop queue))
+                                    (assoc :stack #?(:clj  (conj stack interceptor)
+                                                     :cljs (doto (or stack (array))
+                                                             (.unshift interceptor))))
+                                    (-try (:enter interceptor))))))
+    :else (-invalid-context-type! ctx :enter)))
 
 #?(:clj
    (defn- await-result [ctx get-result]
@@ -86,11 +100,13 @@
    (execute-context interceptors ctx on-complete on-error remove-context-keys))
   ([interceptors ctx on-complete on-error get-result]
    (if-let [queue (q/into-queue interceptors)]
-     (-> (assoc ctx :queue queue :on-complete on-complete :on-error on-error)
-         (map->Context)
-         (enter)
-         (leave)
-         (deliver-result get-result))
+     (try
+       (-> (assoc ctx :queue queue :on-complete on-complete :on-error on-error)
+           (map->Context)
+           (enter)
+           (leave)
+           (deliver-result get-result))
+       (catch #?(:clj Exception :cljs js/Error) e (on-error e)))
      ;; It is always necessary to call on-complete or the computation would not
      ;; keep going.
      (on-complete nil))
@@ -113,10 +129,12 @@
      [interceptors request on-complete on-error])}
   ([interceptors request on-complete on-error]
    (if-let [queue (q/into-queue interceptors)]
-     (-> (request-response-context request queue on-complete on-error)
-         (enter)
-         (leave)
-         (deliver-result :response))
+     (try
+       (-> (request-response-context request queue on-complete on-error)
+           (enter)
+           (leave)
+           (deliver-result :response))
+       (catch #?(:clj Exception :cljs js/Error) e (on-error e)))
      ;; It is always necessary to call on-complete or the computation would not
      ;; keep going.
      (on-complete nil))

--- a/test/clj/sieppari/core_test.clj
+++ b/test/clj/sieppari/core_test.clj
@@ -5,7 +5,7 @@
             [sieppari.async.core-async]
             [clojure.core.async :as a]))
 
-(def try-f #'s/try-f)
+(def try-f #'s/-try)
 
 (deftest try-f-test
   (fact

--- a/test/clj/sieppari/core_test.clj
+++ b/test/clj/sieppari/core_test.clj
@@ -49,43 +49,35 @@
 
 (defn fail! [_] (throw (ex-info "should never get here" {})))
 
+(let [p (promise)]
+  (deliver-result {:response :r} :response p fail!)
+  (fact
+    @p =eventually=> :r))
+
 (deftest deliver-result-test
   (let [p (promise)]
-    (deliver-result {:response :r
-                     :on-complete p
-                     :on-error fail!}
-                    :response)
+    (deliver-result {:response :r} :response p fail!)
     (fact
-      @p =eventually=> :r))
+      @p =eventually=> :r))(let [p (promise)]
+                                 (deliver-result {:response :r} :response p fail!)
+                                 (fact @p =eventually=> :r))
 
   (let [p (promise)]
-    (deliver-result {:error (ex-info "oh no" {})
-                     :on-complete fail!
-                     :on-error p}
-                    :response)
-    (fact
-      @p =eventually=> (ex-info? "oh no" {})))
+    (deliver-result {:response :r} :response p fail!)
+    (fact @p =eventually=> :r))
 
   (let [p (promise)]
-    (deliver-result (a/go {:response :r
-                           :on-complete p
-                           :on-error fail!})
-                    :response)
-    (fact
-      @p =eventually=> :r))
+    (deliver-result {:error (ex-info "oh no" {})} :response fail! p)
+    (fact @p =eventually=> (ex-info? "oh no" {})))
 
   (let [p (promise)]
-    (deliver-result (a/go {:error (ex-info "oh no" {})
-                           :on-complete fail!
-                           :on-error p})
-                    :response)
-    (fact
-      @p =eventually=> (ex-info? "oh no" {})))
+    (deliver-result (a/go {:response :r}) :response p fail!)
+    (fact @p =eventually=> :r))
 
   (let [p (promise)]
-    (deliver-result (future (a/go {:response :r
-                                   :on-complete p
-                                   :on-error fail!}))
-                    :response)
-    (fact
-      @p =eventually=> :r)))
+    (deliver-result (a/go {:error (ex-info "oh no" {})}) :response fail! p)
+    (fact @p =eventually=> (ex-info? "oh no" {})))
+
+  (let [p (promise)]
+    (deliver-result (future (a/go {:response :r})) :response p fail!)
+    (fact @p =eventually=> :r)))


### PR DESCRIPTION
* If the Context is unsupported (satisfies either `AsyncContext` or `Context`), a descriptive error is either thrown (sync) or returned via `on-error` callback (async).
  * This is important for `core.async` users,  which is not supported oob in the future. Without this, the caller would never get any response if the `core.async` support was not enabled.
* Don't pass the `on-complete` and `on-error` via the context, just not needed.