### PR TITLE
combine continue and catch in the async protocol

### DIFF
--- a/src/sieppari/async.cljc
+++ b/src/sieppari/async.cljc
@@ -28,10 +28,11 @@
    (extend-protocol AsyncContext
      clojure.lang.IDeref
      (async? [_] true)
-     (continue [c ctx f] (let [c @c]
-                               (if (exception? c)
-                                 (f (assoc ctx :error c))
-                                 (f c))))
+     (continue [c ctx f]
+       (future (let [c @c]
+                 (if (exception? c)
+                   (f (assoc ctx :error c))
+                   (f c)))))
      (await [c] @c)))
 
 #?(:clj

--- a/src/sieppari/async.cljc
+++ b/src/sieppari/async.cljc
@@ -61,4 +61,5 @@
      (continue [t ctx f]
        (-> t
            (.then f)
-           (.then  (fn [e] (f (assoc ctx :error e))))))))
+           (.catch  (fn [e]
+                      (f (assoc ctx :error e))))))))

--- a/src/sieppari/async.cljc
+++ b/src/sieppari/async.cljc
@@ -3,58 +3,53 @@
   (:require [sieppari.util :refer [exception?]])
   #?(:clj (:import java.util.concurrent.CompletionStage
                    java.util.concurrent.CompletionException
-                   java.util.function.Function)))
+                   java.util.function.Function
+                   java.util.function.BiFunction)))
 
 (defprotocol AsyncContext
   (async? [t])
-  (continue [t f])
-  (catch [c f])
+  (continue [t ctx f])
   #?(:clj (await [t])))
-
-#?(:clj
-   (deftype FunctionWrapper [f]
-     Function
-     (apply [_ v]
-       (f v))))
 
 #?(:clj
    (extend-protocol AsyncContext
      Object
      (async? [_] false)
-     (continue [t f] (f t))
+     (continue [t ctx f] (f t))
      (await [t] t)))
 
 #?(:cljs
    (extend-protocol AsyncContext
      default
      (async? [_] false)
-     (continue [t f] (f t))))
+     (continue [t ctx f] (f t))))
 
 #?(:clj
    (extend-protocol AsyncContext
      clojure.lang.IDeref
      (async? [_] true)
-     (continue [c f] (future (f @c)))
-     (catch [c f] (future (let [c @c]
-                            (if (exception? c) (f c) c))))
+     (continue [c ctx f] (let [c @c]
+                               (if (exception? c)
+                                 (f (assoc ctx :error c))
+                                 (f c))))
      (await [c] @c)))
+
+#?(:clj
+   (deftype BiFunctionContinue [f ctx]
+     BiFunction
+     (apply [_ v e]
+       (if (some? e)
+         (if (instance? CompletionException e)
+           (f (assoc ctx :error (.getCause ^Exception e)))
+           (f (assoc ctx :error e)))
+         (f v)))))
 
 #?(:clj
    (extend-protocol AsyncContext
      CompletionStage
      (async? [_] true)
-     (continue [this f]
-       (.thenApply ^CompletionStage this
-                   ^Function (->FunctionWrapper f)))
-
-     (catch [this f]
-       (letfn [(handler [e]
-                  (if (instance? CompletionException e)
-                   (f (.getCause ^Exception e))
-                   (f e)))]
-         (.exceptionally ^CompletionStage this
-                         ^Function (->FunctionWrapper handler))))
-
+     (continue [this ctx f]
+       (.handle ^CompletionStage this (->BiFunctionContinue f ctx)))
      (await [this]
        (deref this))))
 
@@ -62,5 +57,7 @@
    (extend-protocol AsyncContext
      js/Promise
      (async? [_] true)
-     (continue [t f] (.then t f))
-     (catch [t f] (.catch t f))))
+     (continue [t ctx f]
+       (-> t
+           (.then f)
+           (.then  (fn [e] (f (assoc ctx :error e))))))))

--- a/src/sieppari/async/core_async.cljc
+++ b/src/sieppari/async/core_async.cljc
@@ -5,11 +5,13 @@
              #?@(:clj  [:refer [go <! <!!]]
                  :cljs [:refer-macros [go]])]))
 
+
 (extend-protocol sa/AsyncContext
   #?(:clj  clojure.core.async.impl.protocols.Channel
      :cljs cljs.core.async.impl.channels/ManyToManyChannel)
   (async? [_] true)
-  (continue [c f] (go (f (cca/<! c))))
-  (catch [c f] (go (let [c (cca/<! c)]
-                     (if (exception? c) (f c) c))))
+  (continue [c ctx f] (go (let [c (cca/<! c)]
+                                (if (exception? c)
+                                  (f (assoc ctx :error c))
+                                  (f c)))))
   #?(:clj (await [c] (<!! c))))

--- a/src/sieppari/async/manifold.clj
+++ b/src/sieppari/async/manifold.clj
@@ -5,12 +5,14 @@
 (extend-protocol sa/AsyncContext
   manifold.deferred.Deferred
   (async? [_] true)
-  (continue [d f] (d/chain'- nil d f))
-  (catch [d f] (d/catch' d f))
+  (continue [d ctx f]
+    (-> (d/chain'- nil d f)
+        (d/catch' (fn [e] (f (assoc ctx :error e))))))
   (await [d] (deref d))
 
   manifold.deferred.ErrorDeferred
   (async? [_] true)
-  (continue [d f] (d/chain'- nil d f))
-  (catch [d f] (d/catch' d f))
+  (continue [d ctx f]
+    (-> (d/chain'- nil d f)
+        (d/catch' (fn [e] (f (assoc ctx :error e))))))
   (await [d] (deref d)))

--- a/src/sieppari/interceptor.cljc
+++ b/src/sieppari/interceptor.cljc
@@ -1,6 +1,7 @@
 (ns sieppari.interceptor
   (:require [sieppari.async :as a]
-            [sieppari.util :refer [exception?]]))
+            [sieppari.util :refer [exception?]]
+            [clojure.core :as c]))
 
 (defrecord Interceptor [name enter leave error])
 
@@ -9,7 +10,9 @@
 
 (defn- set-result [ctx response]
   (if (and (some? response) (a/async? response))
-    (a/continue response (partial set-result ctx))
+    (a/continue response ctx (fn [resp] (if (and (map? resp) (:error resp))
+                                         resp
+                                         (assoc ctx :response resp))))
     (assoc ctx
       (if (exception? response) :error :response)
       response)))

--- a/test/clj/sieppari/async/manifold_test.clj
+++ b/test/clj/sieppari/async/manifold_test.clj
@@ -14,7 +14,7 @@
         d (d/deferred)]
     (future
       (d/success! d "foo"))
-    (as/continue d (partial deliver p))
+    (as/continue d nil (partial deliver p))
     (fact
       @p =eventually=> "foo")))
 
@@ -23,7 +23,8 @@
         d (d/deferred)]
     (future
       (d/success! d "foo"))
-    (as/catch (as/continue d (partial deliver p))
+    (as/continue (as/continue d nil (partial deliver p))
+                 nil
               (fn [_] (deliver p "barf")))
     (fact
       @p =eventually=> "foo"))
@@ -32,7 +33,7 @@
         d (d/deferred)]
     (future
       (d/error! d (Exception. "fubar")))
-    (as/catch d (fn [_] (deliver p "foo")))
+    (as/continue d nil (fn [_] (deliver p "foo")))
     (fact
       @p =eventually=> "foo")))
 

--- a/test/clj/sieppari/core_async_test.clj
+++ b/test/clj/sieppari/core_async_test.clj
@@ -2,6 +2,7 @@
   (:require [clojure.test :refer :all]
             [testit.core :refer :all]
             [sieppari.core :as sc]
+            [sieppari.async.core-async]
             [clojure.core.async :refer [go <! <!!]]))
 
 (defn make-logging-interceptor [log name]

--- a/test/clj/sieppari/core_test.clj
+++ b/test/clj/sieppari/core_test.clj
@@ -19,7 +19,7 @@
     =in=> {:error (ex-info? "oh no" {})})
   (fact
     @(try-f {} (fn [_] (future (ex-info "oh no" {}))))
-    =eventually-in=> {:error (ex-info? "oh no" {})}))
+    =eventually-in=> (ex-info? "oh no" {})))
 
 (def await-result #'s/await-result)
 

--- a/test/clj/sieppari/promesa_test.clj
+++ b/test/clj/sieppari/promesa_test.clj
@@ -191,7 +191,7 @@
            (make-logging-interceptor log :c)
            (fn [_]
              (swap! log conj [:handler])
-             (p/resolved error))]
+             (p/rejected error))]
           (sc/execute request))
       =throws=> error)
     (fact
@@ -217,7 +217,7 @@
            (make-logging-interceptor log :c)
            (fn [_]
              (swap! log conj [:handler])
-             (p/resolved error))]
+             (p/rejected error))]
           (sc/execute request))
       => :fixed-by-b)
     (fact

--- a/test/cljc/sieppari/async/core_async_test.cljc
+++ b/test/cljc/sieppari/async/core_async_test.cljc
@@ -10,12 +10,13 @@
 #?(:clj
    (deftest core-async-continue-clj-promise-test
      (let [respond (promise)]
-       (as/continue (a/go "foo") (partial deliver respond))
+       (as/continue (a/go "foo") {} (partial deliver respond))
        (is (= "foo" @respond))))
    :cljs
    (deftest core-async-continue-cljs-callback-test
      (async done
        (is (as/continue (a/go "foo")
+                        {}
                         (fn [response]
                           (is (= "foo" response))
                           (done)))))))
@@ -23,13 +24,13 @@
 #?(:clj
    (deftest core-async-catch-clj-promise-test
      (let [respond (promise)]
-       (as/catch (a/go (Exception. "fubar")) (fn [_] (deliver respond "foo")))
+       (as/continue (a/go (Exception. "fubar")) nil (fn [_] (deliver respond "foo")))
        (is (= "foo" @respond))))
    :cljs
    (deftest core-async-catch-cljs-callback-test
      (async done
-       (is (as/continue (as/catch (a/go (js/Error. "fubar"))
-                                  (fn [_] "foo"))
+       (is (as/continue (a/go (js/Error. "fubar"))
+                        {}
                         (fn [response]
                           (is (= "foo" response))
                           (done)))))))

--- a/test/cljc/sieppari/async/core_async_test.cljc
+++ b/test/cljc/sieppari/async/core_async_test.cljc
@@ -29,11 +29,12 @@
    :cljs
    (deftest core-async-catch-cljs-callback-test
      (async done
-       (is (as/continue (a/go (js/Error. "fubar"))
-                        {}
-                        (fn [response]
-                          (is (= "foo" response))
-                          (done)))))))
+       (let [err (js/Error. "fubar")]
+         (is (as/continue (a/go err)
+                          {}
+                          (fn [response]
+                            (is (= {:error err} response))
+                            (done))))))))
 
 #?(:clj
    (deftest await-test

--- a/test/cljc/sieppari/async/promesa_test.cljc
+++ b/test/cljc/sieppari/async/promesa_test.cljc
@@ -13,7 +13,7 @@
            p (p/create
                (fn [resolve _]
                  (px/schedule! 10 #(resolve "foo"))))]
-       (as/continue p respond)
+       (as/continue p nil respond)
        (is (= @respond "foo"))))
    :cljs
    (deftest core-async-continue-cljs-callback-test
@@ -21,7 +21,7 @@
                (fn [resolve _]
                  (px/schedule! 10 #(resolve "foo"))))]
        (async done
-         (is (as/continue p (fn [response]
+         (is (as/continue p nil (fn [response]
                               (is (= "foo" response))
                               (done))))))))
 
@@ -31,7 +31,7 @@
            p (p/create
                (fn [_ reject]
                  (px/schedule! 10 #(reject (Exception. "fubar")))))]
-       (as/catch p (fn [_] (respond "foo")))
+       (as/continue p nil (fn [_] (respond "foo")))
        (is (= @respond "foo"))))
    :cljs
    (deftest core-async-catch-cljs-callback-test
@@ -39,7 +39,8 @@
                (fn [_ reject]
                  (px/schedule! 10 #(reject (js/Error. "fubar")))))]
        (async done
-         (is (as/continue (as/catch p (fn [_] "foo"))
+         (is (as/continue p
+                          nil
                           (fn [response]
                             (is (= "foo" response))
                             (done))))))))

--- a/test/cljc/sieppari/async/promesa_test.cljc
+++ b/test/cljc/sieppari/async/promesa_test.cljc
@@ -35,14 +35,15 @@
        (is (= @respond "foo"))))
    :cljs
    (deftest core-async-catch-cljs-callback-test
-     (let [p (p/create
+     (let [err (js/Error. "fubar")
+           p (p/create
                (fn [_ reject]
-                 (px/schedule! 10 #(reject (js/Error. "fubar")))))]
+                 (px/schedule! 10 #(reject err))))]
        (async done
          (is (as/continue p
                           nil
                           (fn [response]
-                            (is (= "foo" response))
+                            (is (= {:error err} response))
                             (done))))))))
 
 #?(:clj

--- a/test/cljs/sieppari/native_promise_test.cljs
+++ b/test/cljs/sieppari/native_promise_test.cljs
@@ -166,7 +166,7 @@
            (make-logging-interceptor log :c)
            (fn [_]
              (swap! log conj [:handler])
-             (js/Promise.resolve error))]
+             (js/Promise.reject error))]
           (sc/execute request
                       fail!
                       (fn [response]
@@ -220,7 +220,7 @@
              (make-logging-interceptor log :c)
              (fn [_]
                (swap! log conj [:handler])
-               (js/Promise.resolve error))]
+               (js/Promise.reject error))]
             (sc/execute request
                         (fn [response]
                           (is (= @log


### PR DESCRIPTION
Future and delay are significantly faster if we combine continue and catch in the protocol. 

This pull request adds error handling to the responsibilities of continue. In order to do this well we must pass the context right before the the interceptor function is applied to `continue`s signature. 