### PR TITLE
enable manifold AsyncContext for perf testing

### DIFF
--- a/examples/example/perf_testing.clj
+++ b/examples/example/perf_testing.clj
@@ -3,6 +3,7 @@
             [sieppari.core :as s]
             [sieppari.queue :as sq]
             [sieppari.async.core-async]
+            [sieppari.async.manifold]
             [io.pedestal.interceptor :as pi]
             [io.pedestal.interceptor.chain :as pc]
             [manifold.deferred :as d]

--- a/test/clj/sieppari/manifold_test.clj
+++ b/test/clj/sieppari/manifold_test.clj
@@ -2,6 +2,7 @@
   (:require [clojure.test :refer :all]
             [testit.core :refer :all]
             [sieppari.core :as sc]
+            [sieppari.async.manifold]
             [manifold.deferred :as d]))
 
 (defn make-logging-interceptor [log name]


### PR DESCRIPTION
Note that even after this PR it appears to be using IDeref AsyncContext.