### PR TITLE
We need to add support for the other deferred types in manifold.

### DIFF
--- a/src/sieppari/async/manifold.clj
+++ b/src/sieppari/async/manifold.clj
@@ -13,4 +13,17 @@
   (async? [_] true)
   (continue [d f] (d/chain'- nil d f))
   (catch [d f] (d/catch' d f))
-  (await [d] (deref d)))
+  (await [d] (deref d))
+
+  manifold.deferred.SuccessDeferred
+  (async? [_] true)
+  (continue [d f] (d/chain'- nil d f))
+  (catch [d f] (d/catch' d f))
+  (await [d] (deref d))
+
+  manifold.deferred.LeakAwareDeferred
+  (async? [_] true)
+  (continue [d f] (d/chain'- nil d f))
+  (catch [d f] (d/catch' d f))
+  (await [d] (deref d))
+  )


### PR DESCRIPTION
SuccessDeferred does not have an implementation in  `sieppari.async.manifold`

After accepting this patch and the other that included manifold ]
AsyncContext in the perf test we the performance close to promesa.
around 7us on my machine

We should consider implementing the async protocol on the interface `manifold.deferred.IDeferred`