### PR TITLE
IDeref-to-Future-Delay

### DIFF
--- a/examples/example/perf_testing.clj
+++ b/examples/example/perf_testing.clj
@@ -3,6 +3,7 @@
             [sieppari.core :as s]
             [sieppari.queue :as sq]
             [sieppari.async.core-async]
+            [sieppari.async.manifold]
             [io.pedestal.interceptor :as pi]
             [io.pedestal.interceptor.chain :as pc]
             [manifold.deferred :as d]

--- a/src/sieppari/async/manifold.clj
+++ b/src/sieppari/async/manifold.clj
@@ -13,4 +13,17 @@
   (async? [_] true)
   (continue [d f] (d/chain'- nil d f))
   (catch [d f] (d/catch' d f))
-  (await [d] (deref d)))
+  (await [d] (deref d))
+
+  manifold.deferred.SuccessDeferred
+  (async? [_] true)
+  (continue [d f] (d/chain'- nil d f))
+  (catch [d f] (d/catch' d f))
+  (await [d] (deref d))
+
+  manifold.deferred.LeakAwareDeferred
+  (async? [_] true)
+  (continue [d f] (d/chain'- nil d f))
+  (catch [d f] (d/catch' d f))
+  (await [d] (deref d))
+  )

--- a/test/clj/sieppari/manifold_test.clj
+++ b/test/clj/sieppari/manifold_test.clj
@@ -2,6 +2,7 @@
   (:require [clojure.test :refer :all]
             [testit.core :refer :all]
             [sieppari.core :as sc]
+            [sieppari.async.manifold]
             [manifold.deferred :as d]))
 
 (defn make-logging-interceptor [log name]


### PR DESCRIPTION
Implement AsyncContext on java.util.concurrent.Future and clojure.lang.Delay instead of IDeref.
