### PR TITLE
Add ':binding' support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@ pom.xml.asc
 /.lumo_cache/
 .idea/
 *.iml
+.clj-kondo/.cache/
+.lsp/

--- a/src/sieppari/async/core_async.cljc
+++ b/src/sieppari/async/core_async.cljc
@@ -9,7 +9,11 @@
   #?(:clj  clojure.core.async.impl.protocols.Channel
      :cljs cljs.core.async.impl.channels/ManyToManyChannel)
   (async? [_] true)
-  (continue [c f] (go (f (cca/<! c))))
+  #?(:clj  (continue [c f]
+            (let [f' (sa/-forward-bindings f)]
+              (go 
+                (f' (cca/<! c)))))
+     :cljs (continue [c f] (go (f (cca/<! c)))))
   (catch [c f] (go (let [c (cca/<! c)]
                      (if (exception? c) (f c) c))))
   #?(:clj (await [c] (<!! c))))

--- a/src/sieppari/async/manifold.clj
+++ b/src/sieppari/async/manifold.clj
@@ -2,15 +2,31 @@
   (:require [sieppari.async :as sa]
             [manifold.deferred :as d]))
 
+; chain'-, as is being used here, is chain'-/3
+; chain'-/3, at the time of writing, has an arglist of:
+;  [d x f]
+; where:
+;  - `d` is a non-realized manifold deferred value, or nil
+;    to signal a deferred should be returned/provided
+;  - `x` is either a deferred or a value. If it is a deferred,
+;    then the deferred is recurively realized until a non-deferred value
+;    is yeilded.
+;  - `f` is a function applied to the unwrapped value `x`, before being either realized
+;    into `d` or being returned as a sucess or error deferred, depending on the result
+;    of `(f x)`.
 (extend-protocol sa/AsyncContext
   manifold.deferred.Deferred
   (async? [_] true)
-  (continue [d f] (d/chain'- nil d f))
-  (catch [d f] (d/catch' d f))
+  (continue [d f]
+    (d/chain'- nil d (sa/-forward-bindings f)))
+  (catch [d f]
+    (d/catch' d (sa/-forward-bindings f)))
   (await [d] (deref d))
 
   manifold.deferred.ErrorDeferred
   (async? [_] true)
-  (continue [d f] (d/chain'- nil d f))
-  (catch [d f] (d/catch' d f))
+  (continue [d f]
+    (d/chain'- nil d (sa/-forward-bindings f)))
+  (catch [d f]
+    (d/catch' d (sa/-forward-bindings f)))
   (await [d] (deref d)))

--- a/test/clj/sieppari/core_execute_test.clj
+++ b/test/clj/sieppari/core_execute_test.clj
@@ -269,6 +269,26 @@
         [:leave :x]
         [:leave :a]]))
 
+
+(def ^:dynamic *boundv* 41)
+
+(defn bindings-handler [_]
+  (is (= 42 *boundv*))
+  *boundv*)
+
+(def bindings-chain
+  [{:enter (fn [ctx] (assoc ctx
+                            :bindings
+                            {#'*boundv* 42}))}
+   {:enter (fn [ctx]
+             (is (= 42 *boundv*))
+             ctx)}
+   bindings-handler])
+
+(deftest use-bindings-test
+  (fact "bindings are conveyed across interceptor chain"
+    (s/execute bindings-chain {}) => 42))
+
 ; TODO: figure out how enqueue should work? Should enqueue add interceptors just
 ; before the handler?
 #_(deftest enqueue-interceptor-test

--- a/test/cljc/sieppari/async/promesa_test.cljc
+++ b/test/cljc/sieppari/async/promesa_test.cljc
@@ -8,7 +8,7 @@
   (is (as/async? (p/promise 1))))
 
 #?(:clj
-   (deftest core-async-continue-cljs-callback-test
+   (deftest core-async-continue-clj-callback-test
      (let [respond (promise)
            p (p/create
                (fn [resolve _]
@@ -26,7 +26,7 @@
                               (done))))))))
 
 #?(:clj
-   (deftest core-async-catch-cljs-callback-test
+   (deftest core-async-catch-clj-callback-test
      (let [respond (promise)
            p (p/create
                (fn [_ reject]


### PR DESCRIPTION
### Overview

Per #54, this commit could be considered a starting point for supporting bindings support in Clojure, not ClojureScript, given the platform differences.

The initial implementation used the starting point @robert-stuttaford posted in the referenced issue.


### Performance Tradeoff

A tradeoff here is in order to support sync/async w/ the various runtimes, using `(bound-fn*)` seems to be necessary given the different thread pool implemenations. Counsequently, there looks to be a slight performance hit needing to push/pop thread local vars in the general case. However, manifold seems to be an order of magnitude slower, though still in the microseconds.

Not sure the tradeoff ya'll at metosin want to make here. I'll throw in my 2 cents, in that if manifold is being chosen as the async executor, it isn't being chosen for raw performance.

#### Perf Tests
I ran the following on:
```
System: Macbook Pro 14"
OS:     MacOS
CPU:    Apple M2 Max
RAM:    64GB
```

<details>
<summary>Results of `lein perf-test` before changes</summary>

```shell
###########
queue of 10
###########
##############
pedestal: sync
##############

 3.25µs 

Evaluation count : 183540 in 6 samples of 30590 calls.
             Execution time mean : 3.278964 µs
    Execution time std-deviation : 23.780782 ns
   Execution time lower quantile : 3.254391 µs ( 2.5%)
   Execution time upper quantile : 3.311914 µs (97.5%)
                   Overhead used : 1.550500 ns

####################
pedestal: core.async
####################

 34.19µs 

Evaluation count : 17340 in 6 samples of 2890 calls.
             Execution time mean : 34.577367 µs
    Execution time std-deviation : 289.748259 ns
   Execution time lower quantile : 34.190333 µs ( 2.5%)
   Execution time upper quantile : 34.847592 µs (97.5%)
                   Overhead used : 1.550500 ns

#####################
sieppari: sync (sync)
#####################

 0.81µs 

Evaluation count : 741960 in 6 samples of 123660 calls.
             Execution time mean : 820.501291 ns
    Execution time std-deviation : 7.407250 ns
   Execution time lower quantile : 805.777729 ns ( 2.5%)
   Execution time upper quantile : 824.764815 ns (97.5%)
                   Overhead used : 1.550500 ns

Found 1 outliers in 6 samples (16.6667 %)
	low-severe	 1 (16.6667 %)
 Variance from outliers : 13.8889 % Variance is moderately inflated by outliers

######################
sieppari: sync (async)
######################

 0.83µs 

Evaluation count : 726360 in 6 samples of 121060 calls.
             Execution time mean : 836.618823 ns
    Execution time std-deviation : 5.066484 ns
   Execution time lower quantile : 827.109879 ns ( 2.5%)
   Execution time upper quantile : 840.139743 ns (97.5%)
                   Overhead used : 1.550500 ns

Found 1 outliers in 6 samples (16.6667 %)
	low-severe	 1 (16.6667 %)
 Variance from outliers : 13.8889 % Variance is moderately inflated by outliers

###########################
sieppari: core.async (sync)
###########################

 26.60µs 

Evaluation count : 23124 in 6 samples of 3854 calls.
             Execution time mean : 27.263216 µs
    Execution time std-deviation : 558.994255 ns
   Execution time lower quantile : 26.602173 µs ( 2.5%)
   Execution time upper quantile : 27.950089 µs (97.5%)
                   Overhead used : 1.550500 ns

############################
sieppari: core.async (async)
############################

 26.49µs 

Evaluation count : 22716 in 6 samples of 3786 calls.
             Execution time mean : 26.621071 µs
    Execution time std-deviation : 144.260144 ns
   Execution time lower quantile : 26.489205 µs ( 2.5%)
   Execution time upper quantile : 26.785475 µs (97.5%)
                   Overhead used : 1.550500 ns

########################
sieppari: future (async)
########################

 99.97µs 

Evaluation count : 4752 in 6 samples of 792 calls.
             Execution time mean : 123.093350 µs
    Execution time std-deviation : 24.149759 µs
   Execution time lower quantile : 99.974881 µs ( 2.5%)
   Execution time upper quantile : 152.101362 µs (97.5%)
                   Overhead used : 1.550500 ns

#######################
sieppari: delay (async)
#######################

 80.59µs 

Evaluation count : 6120 in 6 samples of 1020 calls.
             Execution time mean : 109.022435 µs
    Execution time std-deviation : 21.687671 µs
   Execution time lower quantile : 80.585051 µs ( 2.5%)
   Execution time upper quantile : 129.709893 µs (97.5%)
                   Overhead used : 1.550500 ns

#########################
sieppari: deferred (sync)
#########################

 74.65µs 

Evaluation count : 7968 in 6 samples of 1328 calls.
             Execution time mean : 86.410624 µs
    Execution time std-deviation : 12.930944 µs
   Execution time lower quantile : 74.651499 µs ( 2.5%)
   Execution time upper quantile : 104.638934 µs (97.5%)
                   Overhead used : 1.550500 ns

##########################
sieppari: deferred (async)
##########################

 83.05µs 

Evaluation count : 5346 in 6 samples of 891 calls.
             Execution time mean : 111.998925 µs
    Execution time std-deviation : 24.212839 µs
   Execution time lower quantile : 83.046897 µs ( 2.5%)
   Execution time upper quantile : 132.907447 µs (97.5%)
                   Overhead used : 1.550500 ns

########################
sieppari: promesa (sync)
########################

 1.64µs 

Evaluation count : 368550 in 6 samples of 61425 calls.
             Execution time mean : 1.648582 µs
    Execution time std-deviation : 7.853736 ns
   Execution time lower quantile : 1.638825 µs ( 2.5%)
   Execution time upper quantile : 1.655286 µs (97.5%)
                   Overhead used : 1.550500 ns

#########################
sieppari: promesa (async)
#########################

 1.73µs 

Evaluation count : 345144 in 6 samples of 57524 calls.
             Execution time mean : 1.747197 µs
    Execution time std-deviation : 11.476303 ns
   Execution time lower quantile : 1.730098 µs ( 2.5%)
   Execution time upper quantile : 1.759752 µs (97.5%)
                   Overhead used : 1.550500 ns

#######################
homogeneous queue of 10
#######################
########
identity
########

 0.95µs 

Evaluation count : 627444 in 6 samples of 104574 calls.
             Execution time mean : 959.515547 ns
    Execution time std-deviation : 9.100597 ns
   Execution time lower quantile : 950.587058 ns ( 2.5%)
   Execution time upper quantile : 968.715379 ns (97.5%)
                   Overhead used : 1.550500 ns

#######
promesa
#######

 1.72µs 

Evaluation count : 348120 in 6 samples of 58020 calls.
             Execution time mean : 1.744264 µs
    Execution time std-deviation : 15.007995 ns
   Execution time lower quantile : 1.723513 µs ( 2.5%)
   Execution time upper quantile : 1.760065 µs (97.5%)
                   Overhead used : 1.550500 ns

##############################
queue of 9 sync + 1 async step
##############################
########
identity
########

 0.96µs 

Evaluation count : 632502 in 6 samples of 105417 calls.
             Execution time mean : 965.206853 ns
    Execution time std-deviation : 9.167401 ns
   Execution time lower quantile : 956.243310 ns ( 2.5%)
   Execution time upper quantile : 977.271409 ns (97.5%)
                   Overhead used : 1.550500 ns

#######
promesa
#######

 1.09µs 

Evaluation count : 555306 in 6 samples of 92551 calls.
             Execution time mean : 1.097078 µs
    Execution time std-deviation : 5.214203 ns
   Execution time lower quantile : 1.090945 µs ( 2.5%)
   Execution time upper quantile : 1.103462 µs (97.5%)
                   Overhead used : 1.550500 ns

Found 2 outliers in 6 samples (33.3333 %)
	low-severe	 1 (16.6667 %)
	low-mild	 1 (16.6667 %)
 Variance from outliers : 13.8889 % Variance is moderately inflated by outliers

####
comp
####

 0.04µs 

Evaluation count : 15427776 in 6 samples of 2571296 calls.
             Execution time mean : 37.694879 ns
    Execution time std-deviation : 0.299266 ns
   Execution time lower quantile : 37.365965 ns ( 2.5%)
   Execution time upper quantile : 38.082724 ns (97.5%)
                   Overhead used : 1.550500 ns

#########################
pedestal 9 sync + 1 async
#########################

 21.24µs 

Evaluation count : 27588 in 6 samples of 4598 calls.
             Execution time mean : 21.698721 µs
    Execution time std-deviation : 290.594391 ns
   Execution time lower quantile : 21.237022 µs ( 2.5%)
   Execution time upper quantile : 21.987550 µs (97.5%)
                   Overhead used : 1.550500 ns
```
</details>

<details>
<summary>Results of `lein perf-test` after changes</summary>

```shell
###########
queue of 10
###########
##############
pedestal: sync
##############

 3.29µs 

Evaluation count : 182748 in 6 samples of 30458 calls.
             Execution time mean : 3.302733 µs
    Execution time std-deviation : 7.418752 ns
   Execution time lower quantile : 3.293685 µs ( 2.5%)
   Execution time upper quantile : 3.312110 µs (97.5%)
                   Overhead used : 1.619293 ns

Found 2 outliers in 6 samples (33.3333 %)
	low-severe	 1 (16.6667 %)
	low-mild	 1 (16.6667 %)
 Variance from outliers : 13.8889 % Variance is moderately inflated by outliers

####################
pedestal: core.async
####################

 33.62µs 

Evaluation count : 17844 in 6 samples of 2974 calls.
             Execution time mean : 33.952373 µs
    Execution time std-deviation : 199.301855 ns
   Execution time lower quantile : 33.616908 µs ( 2.5%)
   Execution time upper quantile : 34.166529 µs (97.5%)
                   Overhead used : 1.619293 ns

Found 1 outliers in 6 samples (16.6667 %)
	low-severe	 1 (16.6667 %)
 Variance from outliers : 13.8889 % Variance is moderately inflated by outliers

#####################
sieppari: sync (sync)
#####################

 36.22µs 

Evaluation count : 16584 in 6 samples of 2764 calls.
             Execution time mean : 36.282086 µs
    Execution time std-deviation : 48.373302 ns
   Execution time lower quantile : 36.224729 µs ( 2.5%)
   Execution time upper quantile : 36.356861 µs (97.5%)
                   Overhead used : 1.619293 ns

Found 1 outliers in 6 samples (16.6667 %)
	low-severe	 1 (16.6667 %)
 Variance from outliers : 13.8889 % Variance is moderately inflated by outliers

######################
sieppari: sync (async)
######################

 40.16µs 

Evaluation count : 14856 in 6 samples of 2476 calls.
             Execution time mean : 40.246976 µs
    Execution time std-deviation : 63.504983 ns
   Execution time lower quantile : 40.158114 µs ( 2.5%)
   Execution time upper quantile : 40.314585 µs (97.5%)
                   Overhead used : 1.619293 ns

###########################
sieppari: core.async (sync)
###########################

 141.99µs 

Evaluation count : 4224 in 6 samples of 704 calls.
             Execution time mean : 142.764066 µs
    Execution time std-deviation : 655.095479 ns
   Execution time lower quantile : 141.992345 µs ( 2.5%)
   Execution time upper quantile : 143.612439 µs (97.5%)
                   Overhead used : 1.619293 ns

############################
sieppari: core.async (async)
############################

 146.55µs 

Evaluation count : 4116 in 6 samples of 686 calls.
             Execution time mean : 147.451452 µs
    Execution time std-deviation : 931.898548 ns
   Execution time lower quantile : 146.553472 µs ( 2.5%)
   Execution time upper quantile : 148.498519 µs (97.5%)
                   Overhead used : 1.619293 ns

########################
sieppari: future (async)
########################

 265.35µs 

Evaluation count : 2244 in 6 samples of 374 calls.
             Execution time mean : 270.913025 µs
    Execution time std-deviation : 3.579334 µs
   Execution time lower quantile : 265.349094 µs ( 2.5%)
   Execution time upper quantile : 274.583108 µs (97.5%)
                   Overhead used : 1.619293 ns

Found 1 outliers in 6 samples (16.6667 %)
	low-severe	 1 (16.6667 %)
 Variance from outliers : 13.8889 % Variance is moderately inflated by outliers

#######################
sieppari: delay (async)
#######################

 227.67µs 

Evaluation count : 2628 in 6 samples of 438 calls.
             Execution time mean : 229.536433 µs
    Execution time std-deviation : 1.018535 µs
   Execution time lower quantile : 227.668281 µs ( 2.5%)
   Execution time upper quantile : 230.430982 µs (97.5%)
                   Overhead used : 1.619293 ns

Found 1 outliers in 6 samples (16.6667 %)
	low-severe	 1 (16.6667 %)
 Variance from outliers : 13.8889 % Variance is moderately inflated by outliers

#########################
sieppari: deferred (sync)
#########################

 216.74µs 

Evaluation count : 2772 in 6 samples of 462 calls.
             Execution time mean : 218.465373 µs
    Execution time std-deviation : 985.598942 ns
   Execution time lower quantile : 216.737649 µs ( 2.5%)
   Execution time upper quantile : 219.317916 µs (97.5%)
                   Overhead used : 1.619293 ns

##########################
sieppari: deferred (async)
##########################

 229.08µs 

Evaluation count : 2616 in 6 samples of 436 calls.
             Execution time mean : 230.090427 µs
    Execution time std-deviation : 1.044186 µs
   Execution time lower quantile : 229.079995 µs ( 2.5%)
   Execution time upper quantile : 231.251057 µs (97.5%)
                   Overhead used : 1.619293 ns

########################
sieppari: promesa (sync)
########################

 40.88µs 

Evaluation count : 14658 in 6 samples of 2443 calls.
             Execution time mean : 40.914974 µs
    Execution time std-deviation : 36.193651 ns
   Execution time lower quantile : 40.875803 µs ( 2.5%)
   Execution time upper quantile : 40.950534 µs (97.5%)
                   Overhead used : 1.619293 ns

#########################
sieppari: promesa (async)
#########################

 41.86µs 

Evaluation count : 14298 in 6 samples of 2383 calls.
             Execution time mean : 42.002032 µs
    Execution time std-deviation : 92.680345 ns
   Execution time lower quantile : 41.858589 µs ( 2.5%)
   Execution time upper quantile : 42.084247 µs (97.5%)
                   Overhead used : 1.619293 ns

#######################
homogeneous queue of 10
#######################
########
identity
########

 40.36µs 

Evaluation count : 14874 in 6 samples of 2479 calls.
             Execution time mean : 40.423499 µs
    Execution time std-deviation : 42.030929 ns
   Execution time lower quantile : 40.362322 µs ( 2.5%)
   Execution time upper quantile : 40.467753 µs (97.5%)
                   Overhead used : 1.619293 ns

#######
promesa
#######

 41.50µs 

Evaluation count : 14424 in 6 samples of 2404 calls.
             Execution time mean : 41.616959 µs
    Execution time std-deviation : 64.286114 ns
   Execution time lower quantile : 41.495677 µs ( 2.5%)
   Execution time upper quantile : 41.666014 µs (97.5%)
                   Overhead used : 1.619293 ns

Found 1 outliers in 6 samples (16.6667 %)
	low-severe	 1 (16.6667 %)
 Variance from outliers : 13.8889 % Variance is moderately inflated by outliers

##############################
queue of 9 sync + 1 async step
##############################
########
identity
########

 40.40µs 

Evaluation count : 14874 in 6 samples of 2479 calls.
             Execution time mean : 40.436379 µs
    Execution time std-deviation : 28.435846 ns
   Execution time lower quantile : 40.397887 µs ( 2.5%)
   Execution time upper quantile : 40.467560 µs (97.5%)
                   Overhead used : 1.619293 ns

#######
promesa
#######

 40.66µs 

Evaluation count : 14742 in 6 samples of 2457 calls.
             Execution time mean : 40.741821 µs
    Execution time std-deviation : 80.282069 ns
   Execution time lower quantile : 40.658943 µs ( 2.5%)
   Execution time upper quantile : 40.849096 µs (97.5%)
                   Overhead used : 1.619293 ns

####
comp
####

 0.04µs 

Evaluation count : 15212418 in 6 samples of 2535403 calls.
             Execution time mean : 37.913169 ns
    Execution time std-deviation : 0.159909 ns
   Execution time lower quantile : 37.739966 ns ( 2.5%)
   Execution time upper quantile : 38.104962 ns (97.5%)
                   Overhead used : 1.619293 ns

#########################
pedestal 9 sync + 1 async
#########################

 22.23µs 

Evaluation count : 26754 in 6 samples of 4459 calls.
             Execution time mean : 22.590236 µs
    Execution time std-deviation : 359.430478 ns
   Execution time lower quantile : 22.227599 µs ( 2.5%)
   Execution time upper quantile : 23.077110 µs (97.5%)
                   Overhead used : 1.619293 ns
```

</details>